### PR TITLE
Improve atomic write and add README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 UseInsider
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+# cemcp
+
+A minimal file system server built with [MCP-Go](https://github.com/mark3labs/mcp-go). It exposes tools for safe file operations under a configurable root directory and is intended for integration as an MCP tool.
+
+## Features
+
+- Safe path resolution with traversal and symlink escape protection
+- Read and peek utilities with automatic MIME and encoding detection
+- Multiple write strategies: overwrite, no_clobber, append, prepend and replace_range
+- Atomic writes and advisory file locking
+- Directory listing and globbing helpers
+- Optional debug logging to `./log`
+
+## Installation
+
+```bash
+go install github.com/useinsider/cemcp@latest
+```
+
+## Usage
+
+```bash
+cemcp --root /path/to/workspace
+```
+
+The server communicates over stdio. See `main.go` for details on the available tools and arguments.
+
+### Debug Logging
+
+Pass `--debug` to write verbose logs to `./log`.
+
+## Testing
+
+Run unit tests:
+
+```bash
+go test ./... -count=1
+```
+
+With the race detector:
+
+```bash
+go test ./... -race -count=1
+```
+
+Fuzzers (Go 1.18+):
+
+```bash
+GOFLAGS="-tags=go1.18" go test -run=^$ -fuzz=FuzzSafeJoin -fuzztime=30s
+GOFLAGS="-tags=go1.18" go test -run=^$ -fuzz=FuzzEdit -fuzztime=30s
+```
+
+## License
+
+Released under the MIT License. See [LICENSE](LICENSE) for details.
+


### PR DESCRIPTION
## Summary
- fix atomicWrite on Windows by removing existing file before rename
- add symlink escape test and overwrite coverage
- document project and testing in new README

## Testing
- `go test ./... -run Test -count=1 -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689ba6d192148326b1cbdb4a8b54e601