### PR TITLE
Add text search filesystem tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Development Notes
+
+- Always run `go mod download` once the environment starts before running other commands.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A minimal file system server built with [MCP-Go](https://github.com/mark3labs/mc
 - Multiple write strategies: overwrite, no_clobber, append, prepend and replace_range
 - Atomic writes and advisory file locking
 - Directory listing and globbing helpers
+- Content search with substring or regex support
 - Optional debug logging to `./log`
 
 ## Installation
@@ -30,6 +31,12 @@ The server communicates over stdio. See `main.go` for details on the available t
 Pass `--debug` to write verbose logs to `./log`.
 
 ## Testing
+
+Fetch dependencies first:
+
+```bash
+go mod download
+```
 
 Run unit tests:
 

--- a/fs_search_test.go
+++ b/fs_search_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestSearchBasic(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "a.txt"), []byte("hello world\nbye\n"), 0o644)
+	mustWrite(t, filepath.Join(root, "dir", "b.txt"), []byte("world line\nfoo\n"), 0o644)
+
+	search := handleSearch(root)
+	res, err := search(context.Background(), mcp.CallToolRequest{}, SearchArgs{Pattern: "world"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Matches) != 2 {
+		t.Fatalf("want 2 matches, got %d", len(res.Matches))
+	}
+}
+
+func TestSearchRegexAndLimit(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "c.txt"), []byte("cat\ncar\ncap\n"), 0o644)
+
+	search := handleSearch(root)
+	res, err := search(context.Background(), mcp.CallToolRequest{}, SearchArgs{Pattern: "ca.", Regex: true, MaxResults: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Matches) != 2 {
+		t.Fatalf("limit failed, got %d", len(res.Matches))
+	}
+}
+func TestSearchNoPattern(t *testing.T) {
+	root := t.TempDir()
+	search := handleSearch(root)
+	_, err := search(context.Background(), mcp.CallToolRequest{}, SearchArgs{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSearchRegexError(t *testing.T) {
+	root := t.TempDir()
+	search := handleSearch(root)
+	_, err := search(context.Background(), mcp.CallToolRequest{}, SearchArgs{Pattern: "[", Regex: true})
+	if err == nil {
+		t.Fatal("expected regex compile error")
+	}
+}
+
+func TestSearchStartPathAndOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "dir", "f.txt"), []byte("inside"), 0o644)
+	mustWrite(t, filepath.Join(root, "g.txt"), []byte("outside"), 0o644)
+	search := handleSearch(root)
+	res, err := search(context.Background(), mcp.CallToolRequest{}, SearchArgs{Pattern: "i", Path: "dir"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Matches) != 1 || !strings.Contains(res.Matches[0].Path, "dir") {
+		t.Fatalf("unexpected matches: %+v", res.Matches)
+	}
+	// path escaping root should error
+	_, err = search(context.Background(), mcp.CallToolRequest{}, SearchArgs{Pattern: "x", Path: ".."})
+	if err == nil {
+		t.Fatal("expected path error")
+	}
+	_, err = search(context.Background(), mcp.CallToolRequest{}, SearchArgs{Pattern: "x", Path: "missing"})
+	if err == nil {
+		t.Fatal("expected missing path error")
+	}
+}
+
+func TestSearchSymlinkAndErrorIgnored(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "target.txt"), []byte("hi"), 0o644)
+	os.Symlink(filepath.Join(root, "target.txt"), filepath.Join(root, "link.txt"))
+	os.Mkdir(filepath.Join(root, "blocked"), 0o000)
+	search := handleSearch(root)
+	_, err := search(context.Background(), mcp.CallToolRequest{}, SearchArgs{Pattern: "hi"})
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- instruct agents to `go mod download` on startup
- validate search start path and expand unit coverage for fs_search
- document module download in README

## Testing
- `go mod download`
- `go test ./... -count=1`
- `go test -race -count=1`
- `go test ./... -count=1 -coverprofile=cover.out`
- `GOFLAGS="-tags=go1.18" go test -run=^$ -fuzz=FuzzSafeJoin -fuzztime=1s`
- `GOFLAGS="-tags=go1.18" go test -run=^$ -fuzz=FuzzEdit -fuzztime=1s`


------
https://chatgpt.com/codex/tasks/task_e_689ba944ed508326b09c86fe756fc6ae