### PR TITLE
Add sane defaults and caps for context-limited usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A minimal file system server built with [MCP-Go](https://github.com/mark3labs/mc
 - Directory listing and globbing helpers
 - Content search with substring or regex support
 - Optional debug logging to `./log`
+- Sane defaults to limit output: 64KB reads, 4KB peeks, 1000 list/glob entries, 100 search matches
 
 ## Installation
 

--- a/fs_test.go
+++ b/fs_test.go
@@ -285,3 +285,17 @@ func TestRead_MaxBytes_HashAndEncoding(t *testing.T) {
 		t.Fatalf("size mismatch")
 	}
 }
+
+func TestHandleRead_DefaultLimit(t *testing.T) {
+	root := t.TempDir()
+	big := strings.Repeat("a", defaultReadMaxBytes+100)
+	mustWrite(t, filepath.Join(root, "big.txt"), []byte(big), 0o644)
+	rd := handleRead(root)
+	res, err := rd(context.Background(), mcp.CallToolRequest{}, ReadArgs{Path: "big.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Truncated || len(res.Content) != defaultReadMaxBytes {
+		t.Fatalf("expected truncation to %d bytes: %+v", defaultReadMaxBytes, res)
+	}
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -289,3 +289,18 @@ func TestHandleGlobErrors(t *testing.T) {
 		t.Fatalf("expected join error")
 	}
 }
+
+func TestHandleGlobMaxResults(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "a.txt"), []byte(""), 0o644)
+	mustWrite(t, filepath.Join(root, "b.txt"), []byte(""), 0o644)
+	mustWrite(t, filepath.Join(root, "c.txt"), []byte(""), 0o644)
+	gb := handleGlob(root)
+	res, err := gb(context.Background(), mcp.CallToolRequest{}, GlobArgs{Pattern: "*.txt", MaxResults: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Matches) != 2 {
+		t.Fatalf("expected 2 matches, got %d", len(res.Matches))
+	}
+}


### PR DESCRIPTION
## Summary
- cap `fs_read` output to 64KB by default and centralize file system limits
- add optional `max_results` to `fs_glob` and limit list/glob results by default
- document and test output caps for read and glob tools

## Testing
- `go test ./... -count=1`
- `go test ./... -race -count=1`


------
https://chatgpt.com/codex/tasks/task_e_689bb4200f14832694c7efb3d1b8d631