### PR TITLE
refactor: simplify lock helper

### DIFF
--- a/fs_test.go
+++ b/fs_test.go
@@ -143,7 +143,7 @@ func TestAtomicWriteAndLock(t *testing.T) {
 		t.Fatalf("overwrite wrong content: %q err=%v", b, err)
 	}
 
-	rel, err := acquireLock(context.Background(), p, time.Second)
+	rel, err := acquireLock(p, time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +151,7 @@ func TestAtomicWriteAndLock(t *testing.T) {
 	go func() {
 		defer close(done)
 		defer rel() // release the first lock after testing contention
-		_, err := acquireLock(context.Background(), p, 300*time.Millisecond)
+		_, err := acquireLock(p, 300*time.Millisecond)
 		if err == nil {
 			t.Errorf("expected timeout, got nil")
 		}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -178,12 +178,12 @@ func TestKindOf(t *testing.T) {
 
 func TestAcquireLock(t *testing.T) {
 	p := filepath.Join(t.TempDir(), "f")
-	release, err := acquireLock(context.Background(), p, time.Second)
+	release, err := acquireLock(p, time.Second)
 	if err != nil {
 		t.Fatalf("acquireLock failed: %v", err)
 	}
 	defer release()
-	_, err = acquireLock(context.Background(), p, 100*time.Millisecond)
+	_, err = acquireLock(p, 100*time.Millisecond)
 	if err == nil {
 		t.Fatalf("expected lock timeout")
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -169,9 +169,7 @@ func TestLockStale(t *testing.T) {
 	_ = os.WriteFile(p+".lock", []byte("123\n"), 0o644)
 	old := time.Now().Add(-11 * time.Minute)
 	_ = os.Chtimes(p+".lock", old, old)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	release, err := acquireLock(ctx, p, time.Second)
+	release, err := acquireLock(p, time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- simplify `acquireLock` by removing unused context parameter and relying on timeouts
- update write and edit handlers to use the new lock helper
- adjust tests for the revised locking API

## Testing
- `go vet ./...`
- `go test ./...`