### PR TITLE
Expand write coverage with new unit and fuzz tests

### DIFF
--- a/fs_test.go
+++ b/fs_test.go
@@ -211,6 +211,25 @@ func TestHandleWriteStrategies(t *testing.T) {
 	}
 }
 
+func TestHandleWritePrependCreates(t *testing.T) {
+	root := t.TempDir()
+	wr := handleWrite(root)
+	res, err := wr(context.Background(), mcp.CallToolRequest{}, WriteArgs{Path: "new.txt", Encoding: "text", Content: "X", Strategy: strategyPrepend})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(root, "new.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != "X" {
+		t.Fatalf("prepend create wrong: %q", string(b))
+	}
+	if !res.Created {
+		t.Fatalf("expected created true")
+	}
+}
+
 func TestHandleReadAndPeek(t *testing.T) {
 	root := t.TempDir()
 	mustWrite(t, filepath.Join(root, "b.txt"), []byte("hello world"), 0o644)

--- a/fuzz_write_test.go
+++ b/fuzz_write_test.go
@@ -1,0 +1,33 @@
+//go:build go1.18
+// +build go1.18
+
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// FuzzHandleWrite ensures arbitrary inputs do not cause panics.
+func FuzzHandleWrite(f *testing.F) {
+	f.Add("f.txt", []byte("seed"), false)
+	f.Fuzz(func(t *testing.T, path string, data []byte, useBase64 bool) {
+		root := t.TempDir()
+		h := handleWrite(root)
+		enc := string(encText)
+		content := string(data)
+		if useBase64 {
+			enc = string(encBase64)
+			content = base64.StdEncoding.EncodeToString(data)
+		}
+		_, _ = h(context.Background(), mcp.CallToolRequest{}, WriteArgs{
+			Path:       path,
+			Encoding:   enc,
+			Content:    content,
+			CreateDirs: boolPtr(true),
+		})
+	})
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -101,6 +101,9 @@ func TestDetectMIMEAndIsTextExtra(t *testing.T) {
 	if mt := detectMIME("noext", []byte("hi")); mt != "text/plain; charset=utf-8" {
 		t.Fatalf("text detect failed: %s", mt)
 	}
+	if !isText([]byte{'a', '\n', '\r', '\t', 'b'}) {
+		t.Fatalf("expected text with whitespace controls")
+	}
 	if isText([]byte{0, 1, 2}) {
 		t.Fatalf("expected binary not text")
 	}


### PR DESCRIPTION
## Summary
- cover prepend creation in write handler
- ensure MIME text detection handles control whitespace
- fuzz handleWrite to exercise varied inputs

## Testing
- `go test ./...`
- `go test -cover`
- `go test -run=FuzzHandleWrite -fuzz=FuzzHandleWrite -fuzztime=1s`