### PR TITLE
Add benchmark and integration tests

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -173,7 +173,11 @@ func TestKindOf(t *testing.T) {
 			t.Fatalf("want symlink, got %s", k)
 		}
 	}
-	other := kindOf(fakeFileInfo{mode: os.ModeNamedPipe})
+	pipe := kindOf(fakeFileInfo{mode: os.ModeNamedPipe})
+	if pipe != "pipe" {
+		t.Fatalf("want pipe, got %s", pipe)
+	}
+	other := kindOf(fakeFileInfo{mode: os.ModeIrregular})
 	if other != "other" {
 		t.Fatalf("want other, got %s", other)
 	}

--- a/pathutil_benchmark_test.go
+++ b/pathutil_benchmark_test.go
@@ -1,0 +1,12 @@
+package main
+
+import "testing"
+
+func BenchmarkSafeJoin(b *testing.B) {
+	root := b.TempDir()
+	for i := 0; i < b.N; i++ {
+		if _, err := safeJoin(root, "a/b/c.txt"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/mcptest"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func TestWriteReadIntegration(t *testing.T) {
+	root := t.TempDir()
+	srv, err := mcptest.NewServer(t,
+		server.ServerTool{Tool: mcp.NewTool("fs_write"), Handler: mcp.NewStructuredToolHandler(handleWrite(root))},
+		server.ServerTool{Tool: mcp.NewTool("fs_read"), Handler: mcp.NewStructuredToolHandler(handleRead(root))},
+	)
+	if err != nil {
+		t.Fatalf("server start failed: %v", err)
+	}
+	defer srv.Close()
+
+	_, err = srv.Client().CallTool(context.Background(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Name: "fs_write", Arguments: map[string]any{
+			"path": "hello.txt", "encoding": string(encText), "content": "hello",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("write call failed: %v", err)
+	}
+
+	res, err := srv.Client().CallTool(context.Background(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Name: "fs_read", Arguments: map[string]any{
+			"path": "hello.txt",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("read call failed: %v", err)
+	}
+	if len(res.Content) != 1 {
+		t.Fatalf("expected one content entry, got %d", len(res.Content))
+	}
+	text, ok := res.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected text content")
+	}
+	var rr ReadResult
+	if err := json.Unmarshal([]byte(text.Text), &rr); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if rr.Content != "hello" {
+		t.Fatalf("expected content hello, got %q", rr.Content)
+	}
+}


### PR DESCRIPTION
## Summary
- fix `kindOf` unit test to recognize named pipes
- add `safeJoin` benchmark
- add integration test for server read/write tools

## Testing
- `go test ./...`
- `go test -bench BenchmarkSafeJoin -run ^$ ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c635d5f608326a8e18a2d1012f3cc