### PR TITLE
Fix trimUnderRoot root handling and verify compat errors

### DIFF
--- a/compat_handlers_test.go
+++ b/compat_handlers_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// Test that wrapTextHandler propagates errors correctly when compat mode is enabled.
+func TestCompatWrapTextHandlerPropagatesErrors(t *testing.T) {
+	orig := *compatFlag
+	*compatFlag = true
+	t.Cleanup(func() { *compatFlag = orig })
+
+	root := t.TempDir()
+	h := wrapTextHandler(handleRead(root), formatReadResult)
+
+	// Attempt to read path outside the root to force an error.
+	res, err := h(context.Background(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Arguments: map[string]any{"path": "../outside"}},
+	})
+	if err == nil {
+		t.Fatalf("expected error, got nil (res=%v)", res)
+	}
+	if res != nil {
+		t.Fatalf("expected nil result on error, got %v", res)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -18,6 +18,21 @@ func TestTrimUnderRootHandlesSlashRoot(t *testing.T) {
 	}
 }
 
+func TestTrimUnderRootReturnsEmptyForRoot(t *testing.T) {
+	root := t.TempDir()
+	if got := trimUnderRoot(root, root); got != "" {
+		t.Fatalf("expected empty result, got %q", got)
+	}
+}
+
+func TestTrimUnderRootNormalizesPath(t *testing.T) {
+	root := t.TempDir()
+	p := filepath.Join(root, "a", "..", "b")
+	if got := trimUnderRoot(root, p); got != "b" {
+		t.Fatalf("expected 'b', got %q", got)
+	}
+}
+
 func TestReadSkipsHugeHash(t *testing.T) {
 	root := t.TempDir()
 	p := filepath.Join(root, "huge.bin")

--- a/pathutil.go
+++ b/pathutil.go
@@ -94,6 +94,10 @@ func safeJoinResolveFinal(root, reqPath string) (string, error) {
 func trimUnderRoot(root, p string) string {
 	r := mustAbs(root)
 	r = strings.TrimSuffix(r, string(os.PathSeparator))
+	pAbs := mustAbs(p)
+	if pAbs == r {
+		return ""
+	}
 	prefix := r + string(os.PathSeparator)
-	return strings.TrimPrefix(p, prefix)
+	return strings.TrimPrefix(pAbs, prefix)
 }


### PR DESCRIPTION
## Summary
- normalize trimUnderRoot to use absolute paths and handle redundant separators
- add tests covering slash root, root equality, and path normalization
- add regression test for wrapTextHandler error propagation in compat mode

## Testing
- `go test ./...`