### PR TITLE
Remove encoding support and handle long search lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A minimal file-system server built with [MCP-Go](https://github.com/mark3labs/mc
 ## Features
 
 - Safe path resolution with traversal and symlink escape protection
-- Read and peek utilities with automatic MIME and encoding detection
+- Read and peek utilities with automatic MIME detection
 - Multiple write strategies: overwrite, no_clobber, append, prepend, and replace_range
 - Atomic writes and advisory file locking
 - Directory listing and globbing with `**` for recursion
@@ -46,7 +46,6 @@ Read a file.
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `path` | string | File path or `file://` URI. |
-| `encoding` | string | Optional `text` or `base64`; auto-detected if omitted. |
 | `max_bytes` | number | Maximum bytes to return (default 64&nbsp;KiB). |
 
 ### `fs_peek`
@@ -64,7 +63,6 @@ Create or modify a file.
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `path` | string | Target file path. |
-| `encoding` | string | Content encoding: `text` or `base64`. |
 | `content` | string | Data to write. |
 | `strategy` | string | `overwrite`, `no_clobber`, `append`, `prepend`, or `replace_range` (default `overwrite`). |
 | `create_dirs` | boolean | Create parent directories (default false). |

--- a/errors.go
+++ b/errors.go
@@ -20,7 +20,6 @@ var (
 	ErrInsufficientSpace = errors.New("insufficient disk space")
 	ErrFileTooLarge      = errors.New("file exceeds size limit")
 	ErrLockTimeout       = errors.New("lock acquisition timeout")
-	ErrInvalidEncoding   = errors.New("invalid encoding specified")
 	ErrInvalidStrategy   = errors.New("invalid write strategy")
 
 	// Pattern errors

--- a/fs_handlers_test.go
+++ b/fs_handlers_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/base64"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,11 +9,10 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
-func TestWrite_Base64PathAndMode(t *testing.T) {
+func TestWrite_PathAndMode(t *testing.T) {
 	root := t.TempDir()
 	wr := handleWrite(root)
-	data := base64.StdEncoding.EncodeToString([]byte("hello"))
-	res, err := wr(context.Background(), mcp.CallToolRequest{}, WriteArgs{Path: "m/sub/file.txt", Encoding: "base64", Content: data, Mode: "0640", CreateDirs: boolPtr(true)})
+	res, err := wr(context.Background(), mcp.CallToolRequest{}, WriteArgs{Path: "m/sub/file.txt", Content: "hello", Mode: "0640", CreateDirs: boolPtr(true)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -27,20 +25,6 @@ func TestWrite_Base64PathAndMode(t *testing.T) {
 	}
 	if st.Mode()&0o777 != 0o640 {
 		t.Fatalf("mode mismatch: %o", st.Mode()&0o777)
-	}
-}
-
-func TestPeek_BinaryBase64(t *testing.T) {
-	root := t.TempDir()
-	p := filepath.Join(root, "b.bin")
-	os.WriteFile(p, []byte{0, 1, 2, 3, 4, 5}, 0o644)
-	pk := handlePeek(root)
-	res, err := pk(context.Background(), mcp.CallToolRequest{}, PeekArgs{Path: "b.bin", Offset: 1, MaxBytes: 2})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if res.Encoding != string(encBase64) {
-		t.Fatalf("want base64 for binary, got %s", res.Encoding)
 	}
 }
 

--- a/fuzz_write_test.go
+++ b/fuzz_write_test.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"encoding/base64"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -13,20 +12,13 @@ import (
 
 // FuzzHandleWrite ensures arbitrary inputs do not cause panics.
 func FuzzHandleWrite(f *testing.F) {
-	f.Add("f.txt", []byte("seed"), false)
-	f.Fuzz(func(t *testing.T, path string, data []byte, useBase64 bool) {
+	f.Add("f.txt", []byte("seed"))
+	f.Fuzz(func(t *testing.T, path string, data []byte) {
 		root := t.TempDir()
 		h := handleWrite(root)
-		enc := string(encText)
-		content := string(data)
-		if useBase64 {
-			enc = string(encBase64)
-			content = base64.StdEncoding.EncodeToString(data)
-		}
 		_, _ = h(context.Background(), mcp.CallToolRequest{}, WriteArgs{
 			Path:       path,
-			Encoding:   enc,
-			Content:    content,
+			Content:    string(data),
 			CreateDirs: boolPtr(true),
 		})
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -56,9 +56,8 @@ func TestWriteCreateDirsDefaultFalse(t *testing.T) {
 	root := t.TempDir()
 	h := handleWrite(root)
 	_, err := h(context.Background(), mcp.CallToolRequest{}, WriteArgs{
-		Path:     "nested/dir/file.txt",
-		Encoding: string(encText),
-		Content:  "hi",
+		Path:    "nested/dir/file.txt",
+		Content: "hi",
 	})
 	if err == nil {
 		t.Fatalf("expected error when creating dirs not opted in")
@@ -73,9 +72,8 @@ func TestOverwritePreservesModeWhenEmpty(t *testing.T) {
 	}
 	h := handleWrite(root)
 	if _, err := h(context.Background(), mcp.CallToolRequest{}, WriteArgs{
-		Path:     "f.txt",
-		Encoding: string(encText),
-		Content:  "v2",
+		Path:    "f.txt",
+		Content: "v2",
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -96,10 +94,9 @@ func TestOverwriteChangesModeWhenProvided(t *testing.T) {
 	}
 	h := handleWrite(root)
 	if _, err := h(context.Background(), mcp.CallToolRequest{}, WriteArgs{
-		Path:     "f2.txt",
-		Encoding: string(encText),
-		Content:  "v2",
-		Mode:     "0644",
+		Path:    "f2.txt",
+		Content: "v2",
+		Mode:    "0644",
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/peek.go
+++ b/peek.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -45,7 +44,7 @@ func readWindow(path string, offset, max int) ([]byte, int64, bool, error) {
 }
 
 func formatPeekResult(r PeekResult) string {
-	return fmt.Sprintf("path=%s offset=%d size=%d eof=%v enc=%s content=%s", r.Path, r.Offset, r.Size, r.EOF, r.Encoding, r.Content)
+	return fmt.Sprintf("path=%s offset=%d size=%d eof=%v content=%s", r.Path, r.Offset, r.Size, r.EOF, r.Content)
 }
 
 func handlePeek(root string) mcp.StructuredToolHandlerFunc[PeekArgs, PeekResult] {
@@ -66,12 +65,7 @@ func handlePeek(root string) mcp.StructuredToolHandlerFunc[PeekArgs, PeekResult]
 			dprintf("fs_peek read error: %v", err)
 			return res, err
 		}
-		enc := string(encText)
 		content := string(chunk)
-		if !isText(chunk) {
-			enc = string(encBase64)
-			content = base64.StdEncoding.EncodeToString(chunk)
-		}
 		var mode string
 		var modAt string
 		if fi, statErr := os.Lstat(full); statErr == nil {
@@ -79,12 +73,11 @@ func handlePeek(root string) mcp.StructuredToolHandlerFunc[PeekArgs, PeekResult]
 			modAt = fi.ModTime().UTC().Format(time.RFC3339)
 		}
 		res = PeekResult{
-			Path:     args.Path,
-			Offset:   args.Offset,
-			Size:     sz,
-			EOF:      eof,
-			Encoding: enc,
-			Content:  content,
+			Path:    args.Path,
+			Offset:  args.Offset,
+			Size:    sz,
+			EOF:     eof,
+			Content: content,
 			MetaFields: MetaFields{
 				Mode:       mode,
 				ModifiedAt: modAt,

--- a/search_long_line_test.go
+++ b/search_long_line_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSearchFileHandlesLongLines(t *testing.T) {
+	config := DefaultSearchConfig()
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "long.txt")
+	longSize := 1 << 20
+	longLine := strings.Repeat("a", longSize) + "needle\n"
+	if err := os.WriteFile(tmpFile, []byte(longLine), 0644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	matches, bytesRead := searchFile(tmpFile, "needle", nil, tmpDir, 10, config)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if bytesRead == 0 {
+		t.Fatalf("expected bytesRead > 0")
+	}
+}

--- a/server.go
+++ b/server.go
@@ -26,9 +26,8 @@ func setupServer(root string) *server.MCPServer {
 	s := server.NewMCPServer("fs-mcp-go", "0.1.0")
 
 	readOpts := []mcp.ToolOption{
-		mcp.WithDescription("Read a file up to a byte limit. Detects encoding when unspecified."),
+		mcp.WithDescription("Read a file up to a byte limit."),
 		mcp.WithString("path", mcp.Required(), mcp.Description("File path or file:// URI within root")),
-		mcp.WithString("encoding", mcp.Enum(string(encText), string(encBase64)), mcp.Description("Force text or base64; auto-detected if empty")),
 		mcp.WithNumber("max_bytes", mcp.Min(1), mcp.Description("Maximum bytes to return (default 64 KiB)")),
 	}
 	if !*compatFlag {
@@ -60,7 +59,6 @@ func setupServer(root string) *server.MCPServer {
 	writeOpts := []mcp.ToolOption{
 		mcp.WithDescription("Create or modify a file using a strategy"),
 		mcp.WithString("path", mcp.Required(), mcp.Description("Target file path")),
-		mcp.WithString("encoding", mcp.Required(), mcp.Enum(string(encText), string(encBase64)), mcp.Description("Content encoding: text or base64")),
 		mcp.WithString("content", mcp.Required(), mcp.Description("Data to write")),
 		mcp.WithString("strategy", mcp.Enum(string(strategyOverwrite), string(strategyNoClobber), string(strategyAppend), string(strategyPrepend), string(strategyReplaceRange)), mcp.Description("Write behavior (default overwrite)")),
 		mcp.WithBoolean("create_dirs", mcp.Description("Create parent directories if needed (default false)")),

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -23,7 +23,7 @@ func TestWriteReadIntegration(t *testing.T) {
 
 	_, err = srv.Client().CallTool(context.Background(), mcp.CallToolRequest{
 		Params: mcp.CallToolParams{Name: "fs_write", Arguments: map[string]any{
-			"path": "hello.txt", "encoding": string(encText), "content": "hello",
+			"path": "hello.txt", "content": "hello",
 		}},
 	})
 	if err != nil {

--- a/types.go
+++ b/types.go
@@ -11,14 +11,6 @@ const (
 	strategyReplaceRange writeStrategy = "replace_range" // Replace specific byte range
 )
 
-// Encoding types for file content
-type encodingKind string
-
-const (
-	encText   encodingKind = "text"   // UTF-8 text content
-	encBase64 encodingKind = "base64" // Base64 encoded binary
-)
-
 // MetaFields contains common file metadata
 type MetaFields struct {
 	Mode       string `json:"mode,omitempty"`        // File permissions in octal
@@ -28,7 +20,6 @@ type MetaFields struct {
 // ReadArgs defines parameters for reading files
 type ReadArgs struct {
 	Path     string `json:"path" description:"File path or file:// URI within root"`
-	Encoding string `json:"encoding,omitempty" description:"Force text or base64; auto-detected if empty"`
 	MaxBytes int    `json:"max_bytes,omitempty" description:"Maximum bytes to return (default 64KB)"`
 }
 
@@ -38,7 +29,6 @@ type ReadResult struct {
 	Size      int64  `json:"size" description:"Total file size in bytes"`
 	MIMEType  string `json:"mime_type" description:"Detected MIME type"`
 	SHA256    string `json:"sha256" description:"SHA256 hash of content (if under 32MB)"`
-	Encoding  string `json:"encoding" description:"Content encoding used (text/base64)"`
 	Content   string `json:"content" description:"File content (possibly truncated)"`
 	Truncated bool   `json:"truncated" description:"Whether content was truncated"`
 	MetaFields
@@ -53,19 +43,17 @@ type PeekArgs struct {
 
 // PeekResult contains file peek operation results
 type PeekResult struct {
-	Path     string `json:"path" description:"Original requested path"`
-	Offset   int    `json:"offset" description:"Starting byte offset"`
-	Size     int64  `json:"size" description:"Total file size"`
-	EOF      bool   `json:"eof" description:"Whether window reached end of file"`
-	Encoding string `json:"encoding" description:"Content encoding (text/base64)"`
-	Content  string `json:"content" description:"Window content"`
+	Path    string `json:"path" description:"Original requested path"`
+	Offset  int    `json:"offset" description:"Starting byte offset"`
+	Size    int64  `json:"size" description:"Total file size"`
+	EOF     bool   `json:"eof" description:"Whether window reached end of file"`
+	Content string `json:"content" description:"Window content"`
 	MetaFields
 }
 
 // WriteArgs defines parameters for writing files
 type WriteArgs struct {
 	Path       string        `json:"path" description:"Target file path"`
-	Encoding   string        `json:"encoding" description:"Content encoding: text or base64"`
 	Content    string        `json:"content" description:"Data to write"`
 	Strategy   writeStrategy `json:"strategy,omitempty" description:"Write behavior (default overwrite)"`
 	CreateDirs *bool         `json:"create_dirs,omitempty" description:"Create parent directories if needed"`


### PR DESCRIPTION
## Summary
- drop encoding parameters and always treat content as text across read, write, and peek operations
- process arbitrarily long lines during search without skipping
- cover long-line handling with a dedicated unit test

## Testing
- `go test ./... -v`