### PR TITLE
Clarify MCP tool descriptions and add directory tools

### DIFF
--- a/mkdir.go
+++ b/mkdir.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func formatMkdirResult(r MkdirResult) string {
+	return fmt.Sprintf("path=%s created=%v mode=%s modified_at=%s", r.Path, r.Created, r.Mode, r.ModifiedAt)
+}
+
+func handleMkdir(root string) mcp.StructuredToolHandlerFunc[MkdirArgs, MkdirResult] {
+	return func(ctx context.Context, req mcp.CallToolRequest, args MkdirArgs) (MkdirResult, error) {
+		start := time.Now()
+		dprintf("-> fs_mkdir path=%q parents=%v mode=%s", args.Path, args.Parents, args.Mode)
+		var out MkdirResult
+		full, err := safeJoin(root, args.Path)
+		if err != nil {
+			dprintf("fs_mkdir error: %v", err)
+			return out, err
+		}
+		mode, err := parseMode(args.Mode)
+		if err != nil {
+			dprintf("fs_mkdir mode error: %v", err)
+			return out, fmt.Errorf("invalid mode: %w", err)
+		}
+		if args.Mode == "" {
+			mode = 0o755
+		}
+		created := false
+		if fi, err := os.Lstat(full); err == nil {
+			if !fi.IsDir() {
+				dprintf("fs_mkdir exists but not dir")
+				return out, fmt.Errorf("exists and not a directory: %s", args.Path)
+			}
+		} else if os.IsNotExist(err) {
+			if args.Parents {
+				if err := os.MkdirAll(full, mode); err != nil {
+					dprintf("fs_mkdir MkdirAll error: %v", err)
+					return out, err
+				}
+			} else {
+				if err := os.Mkdir(full, mode); err != nil {
+					dprintf("fs_mkdir Mkdir error: %v", err)
+					return out, err
+				}
+			}
+			created = true
+		} else {
+			dprintf("fs_mkdir lstat error: %v", err)
+			return out, err
+		}
+		fi, err := os.Lstat(full)
+		if err != nil {
+			dprintf("fs_mkdir stat error: %v", err)
+			return out, err
+		}
+		out = MkdirResult{
+			Path:    args.Path,
+			Created: created,
+			MetaFields: MetaFields{
+				Mode:       fmt.Sprintf("%#o", fi.Mode()&os.ModePerm),
+				ModifiedAt: fi.ModTime().UTC().Format(time.RFC3339),
+			},
+		}
+		dprintf("<- fs_mkdir ok created=%v dur=%s", created, time.Since(start))
+		return out, nil
+	}
+}

--- a/mkdir_rmdir_test.go
+++ b/mkdir_rmdir_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestMkdirAndRmdir(t *testing.T) {
+	root := t.TempDir()
+	mk := handleMkdir(root)
+	rm := handleRmdir(root)
+
+	res, err := mk(context.Background(), mcp.CallToolRequest{}, MkdirArgs{Path: "a/b", Parents: true, Mode: "755"})
+	if err != nil || !res.Created {
+		t.Fatalf("mkdir failed: %+v err=%v", res, err)
+	}
+	info, err := os.Stat(filepath.Join(root, "a", "b"))
+	if err != nil || !info.IsDir() {
+		t.Fatalf("directory not created: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "a", "b", "f.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	_, err = rm(context.Background(), mcp.CallToolRequest{}, RmdirArgs{Path: "a", Recursive: true})
+	if err != nil {
+		t.Fatalf("rmdir failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "a")); !os.IsNotExist(err) {
+		t.Fatalf("directory not removed: %v", err)
+	}
+}

--- a/rmdir.go
+++ b/rmdir.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func formatRmdirResult(r RmdirResult) string {
+	return fmt.Sprintf("path=%s removed=%v", r.Path, r.Removed)
+}
+
+func handleRmdir(root string) mcp.StructuredToolHandlerFunc[RmdirArgs, RmdirResult] {
+	return func(ctx context.Context, req mcp.CallToolRequest, args RmdirArgs) (RmdirResult, error) {
+		start := time.Now()
+		dprintf("-> fs_rmdir path=%q recursive=%v", args.Path, args.Recursive)
+		var out RmdirResult
+		full, err := safeJoin(root, args.Path)
+		if err != nil {
+			dprintf("fs_rmdir error: %v", err)
+			return out, err
+		}
+		fi, err := os.Lstat(full)
+		if err != nil {
+			dprintf("fs_rmdir lstat error: %v", err)
+			return out, err
+		}
+		if !fi.IsDir() {
+			dprintf("fs_rmdir not a directory")
+			return out, fmt.Errorf("not a directory: %s", args.Path)
+		}
+		if args.Recursive {
+			if err := os.RemoveAll(full); err != nil {
+				dprintf("fs_rmdir RemoveAll error: %v", err)
+				return out, err
+			}
+		} else {
+			if err := os.Remove(full); err != nil {
+				dprintf("fs_rmdir Remove error: %v", err)
+				return out, err
+			}
+		}
+		out = RmdirResult{Path: args.Path, Removed: true}
+		dprintf("<- fs_rmdir ok removed=true dur=%s", time.Since(start))
+		return out, nil
+	}
+}

--- a/types.go
+++ b/types.go
@@ -20,7 +20,7 @@ type MetaFields struct {
 // ReadArgs defines parameters for reading files
 type ReadArgs struct {
 	Path     string `json:"path" description:"File path or file:// URI within root"`
-	MaxBytes int    `json:"max_bytes,omitempty" description:"Maximum bytes to return (default 64KB)"`
+	MaxBytes int    `json:"max_bytes,omitempty" description:"Maximum bytes to return"`
 }
 
 // ReadResult contains file read operation results
@@ -37,8 +37,8 @@ type ReadResult struct {
 // PeekArgs defines parameters for peeking into files
 type PeekArgs struct {
 	Path     string `json:"path" description:"File path"`
-	Offset   int    `json:"offset,omitempty" description:"Byte offset to start at (default 0)"`
-	MaxBytes int    `json:"max_bytes,omitempty" description:"Window size in bytes (default 4KB)"`
+	Offset   int    `json:"offset,omitempty" description:"Byte offset to start at"`
+	MaxBytes int    `json:"max_bytes,omitempty" description:"Window size in bytes"`
 }
 
 // PeekResult contains file peek operation results
@@ -55,9 +55,9 @@ type PeekResult struct {
 type WriteArgs struct {
 	Path       string        `json:"path" description:"Target file path"`
 	Content    string        `json:"content" description:"Data to write"`
-	Strategy   writeStrategy `json:"strategy,omitempty" description:"Write behavior (default overwrite)"`
+	Strategy   writeStrategy `json:"strategy,omitempty" description:"Write strategy: overwrite, no_clobber, append, prepend, replace_range"`
 	CreateDirs *bool         `json:"create_dirs,omitempty" description:"Create parent directories if needed"`
-	Mode       string        `json:"mode,omitempty" description:"File mode in octal (e.g., 0644)"`
+	Mode       string        `json:"mode,omitempty" description:"File mode in octal, e.g. 0644"`
 	Start      *int          `json:"start,omitempty" description:"Start byte for replace_range strategy"`
 	End        *int          `json:"end,omitempty" description:"End byte (exclusive) for replace_range"`
 }
@@ -77,9 +77,9 @@ type WriteResult struct {
 type EditArgs struct {
 	Path    string `json:"path" description:"Target text file"`
 	Pattern string `json:"pattern" description:"Substring or regex to match"`
-	Replace string `json:"replace" description:"Replacement text"`
+	Replace string `json:"replace" description:"Replacement text; $1 etc. works in regex mode"`
 	Regex   bool   `json:"regex,omitempty" description:"Treat pattern as regex"`
-	Count   int    `json:"count,omitempty" description:"Max replacements (0=all)"`
+	Count   int    `json:"count,omitempty" description:"Maximum replacements; 0 means all"`
 }
 
 // EditResult contains file edit operation results
@@ -115,7 +115,7 @@ type ListResult struct {
 
 // GlobArgs defines parameters for glob pattern matching
 type GlobArgs struct {
-	Pattern    string `json:"pattern" description:"Glob pattern (supports ** for recursion)"`
+	Pattern    string `json:"pattern" description:"Glob pattern; ** enables recursion"`
 	MaxResults int    `json:"max_results,omitempty" description:"Maximum matches to return"`
 }
 
@@ -127,7 +127,7 @@ type GlobResult struct {
 // SearchArgs defines parameters for text search
 type SearchArgs struct {
 	Pattern    string `json:"pattern" description:"Text or regex pattern to find"`
-	Path       string `json:"path,omitempty" description:"Start directory (default root)"`
+	Path       string `json:"path,omitempty" description:"Start directory relative to root"`
 	Regex      bool   `json:"regex,omitempty" description:"Interpret pattern as regex"`
 	MaxResults int    `json:"max_results,omitempty" description:"Maximum matches to return"`
 }
@@ -143,4 +143,30 @@ type SearchMatch struct {
 type SearchResult struct {
 	Matches    []SearchMatch          `json:"matches" description:"Found matches"`
 	Statistics map[string]interface{} `json:"statistics,omitempty" description:"Search statistics"`
+}
+
+// MkdirArgs defines parameters for creating directories
+type MkdirArgs struct {
+	Path    string `json:"path" description:"Directory path to create"`
+	Parents bool   `json:"parents,omitempty" description:"Create parent directories if needed"`
+	Mode    string `json:"mode,omitempty" description:"Directory mode in octal"`
+}
+
+// MkdirResult contains directory creation results
+type MkdirResult struct {
+	Path    string `json:"path" description:"Directory path created"`
+	Created bool   `json:"created" description:"Whether directory was newly created"`
+	MetaFields
+}
+
+// RmdirArgs defines parameters for removing directories
+type RmdirArgs struct {
+	Path      string `json:"path" description:"Directory to remove"`
+	Recursive bool   `json:"recursive,omitempty" description:"Remove directory contents recursively"`
+}
+
+// RmdirResult contains directory removal results
+type RmdirResult struct {
+	Path    string `json:"path" description:"Directory removed"`
+	Removed bool   `json:"removed" description:"Whether directory was removed"`
 }


### PR DESCRIPTION
## Summary
- remove default-value chatter and vague wording from tool descriptions
- explicitly list supported fs_write strategies
- streamline search and glob descriptions
- add fs_mkdir and fs_rmdir to create and remove directories

## Testing
- `go test -v ./...`