### PR TITLE
Fix compat flag structured output

### DIFF
--- a/services/filesystem/compat_handlers_test.go
+++ b/services/filesystem/compat_handlers_test.go
@@ -32,6 +32,23 @@ func TestCompatWrapTextHandlerPropagatesErrors(t *testing.T) {
 	}
 }
 
+// Test that wrapStructuredHandler propagates errors and returns no result.
+func TestStructuredHandlerPropagatesErrors(t *testing.T) {
+	root := t.TempDir()
+	h := wrapStructuredHandler(handleRead(root))
+
+	// Attempt to read path outside the root to force an error.
+	res, err := h(context.Background(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Arguments: map[string]any{"path": "../outside"}},
+	})
+	if err == nil {
+		t.Fatalf("expected error, got nil (res=%v)", res)
+	}
+	if res != nil {
+		t.Fatalf("expected nil result on error, got %v", res)
+	}
+}
+
 func TestStructuredHandlerOmitsTextContent(t *testing.T) {
 	root := t.TempDir()
 	p := filepath.Join(root, "f.txt")

--- a/services/filesystem/compat_handlers_test.go
+++ b/services/filesystem/compat_handlers_test.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -25,5 +29,35 @@ func TestCompatWrapTextHandlerPropagatesErrors(t *testing.T) {
 	}
 	if res != nil {
 		t.Fatalf("expected nil result on error, got %v", res)
+	}
+}
+
+func TestStructuredHandlerOmitsTextContent(t *testing.T) {
+	root := t.TempDir()
+	p := filepath.Join(root, "f.txt")
+	if err := os.WriteFile(p, []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := wrapStructuredHandler(handleRead(root))
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{"path": "f.txt"}}}
+	res, err := h(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StructuredContent == nil {
+		t.Fatalf("expected structured content")
+	}
+	if res.Content == nil {
+		t.Fatalf("expected empty content slice")
+	}
+	if len(res.Content) != 0 {
+		t.Fatalf("expected no text content, got %v", res.Content)
+	}
+	data, err := json.Marshal(res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "\"content\":[]") {
+		t.Fatalf("expected JSON content array to be empty, got %s", data)
 	}
 }

--- a/services/filesystem/server.go
+++ b/services/filesystem/server.go
@@ -22,6 +22,20 @@ func wrapTextHandler[TArgs any, TResult any](h mcp.StructuredToolHandlerFunc[TAr
 	}
 }
 
+func wrapStructuredHandler[TArgs any, TResult any](h mcp.StructuredToolHandlerFunc[TArgs, TResult]) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		var args TArgs
+		if err := req.BindArguments(&args); err != nil {
+			return nil, fmt.Errorf("failed to bind arguments: %w", err)
+		}
+		res, err := h(ctx, req, args)
+		if err != nil {
+			return nil, err
+		}
+		return &mcp.CallToolResult{StructuredContent: res, Content: []mcp.Content{}}, nil
+	}
+}
+
 func setupServer(root string) *server.MCPServer {
 	s := server.NewMCPServer("fs-mcp-go", "0.1.0")
 
@@ -37,7 +51,7 @@ func setupServer(root string) *server.MCPServer {
 	if *compatFlag {
 		s.AddTool(readTool, wrapTextHandler(handleRead(root), formatReadResult))
 	} else {
-		s.AddTool(readTool, mcp.NewStructuredToolHandler(handleRead(root)))
+		s.AddTool(readTool, wrapStructuredHandler(handleRead(root)))
 	}
 
 	peekOpts := []mcp.ToolOption{
@@ -53,7 +67,7 @@ func setupServer(root string) *server.MCPServer {
 	if *compatFlag {
 		s.AddTool(peekTool, wrapTextHandler(handlePeek(root), formatPeekResult))
 	} else {
-		s.AddTool(peekTool, mcp.NewStructuredToolHandler(handlePeek(root)))
+		s.AddTool(peekTool, wrapStructuredHandler(handlePeek(root)))
 	}
 
 	writeOpts := []mcp.ToolOption{
@@ -73,7 +87,7 @@ func setupServer(root string) *server.MCPServer {
 	if *compatFlag {
 		s.AddTool(writeTool, wrapTextHandler(handleWrite(root), formatWriteResult))
 	} else {
-		s.AddTool(writeTool, mcp.NewStructuredToolHandler(handleWrite(root)))
+		s.AddTool(writeTool, wrapStructuredHandler(handleWrite(root)))
 	}
 
 	editOpts := []mcp.ToolOption{
@@ -91,7 +105,7 @@ func setupServer(root string) *server.MCPServer {
 	if *compatFlag {
 		s.AddTool(editTool, wrapTextHandler(handleEdit(root), formatEditResult))
 	} else {
-		s.AddTool(editTool, mcp.NewStructuredToolHandler(handleEdit(root)))
+		s.AddTool(editTool, wrapStructuredHandler(handleEdit(root)))
 	}
 
 	listOpts := []mcp.ToolOption{
@@ -107,7 +121,7 @@ func setupServer(root string) *server.MCPServer {
 	if *compatFlag {
 		s.AddTool(listTool, wrapTextHandler(handleList(root), formatListResult))
 	} else {
-		s.AddTool(listTool, mcp.NewStructuredToolHandler(handleList(root)))
+		s.AddTool(listTool, wrapStructuredHandler(handleList(root)))
 	}
 
 	searchOpts := []mcp.ToolOption{
@@ -124,7 +138,7 @@ func setupServer(root string) *server.MCPServer {
 	if *compatFlag {
 		s.AddTool(searchTool, wrapTextHandler(handleSearch(root), formatSearchResult))
 	} else {
-		s.AddTool(searchTool, mcp.NewStructuredToolHandler(handleSearch(root)))
+		s.AddTool(searchTool, wrapStructuredHandler(handleSearch(root)))
 	}
 
 	globOpts := []mcp.ToolOption{
@@ -139,7 +153,7 @@ func setupServer(root string) *server.MCPServer {
 	if *compatFlag {
 		s.AddTool(globTool, wrapTextHandler(handleGlob(root), formatGlobResult))
 	} else {
-		s.AddTool(globTool, mcp.NewStructuredToolHandler(handleGlob(root)))
+		s.AddTool(globTool, wrapStructuredHandler(handleGlob(root)))
 	}
 
 	mkdirOpts := []mcp.ToolOption{
@@ -155,7 +169,7 @@ func setupServer(root string) *server.MCPServer {
 	if *compatFlag {
 		s.AddTool(mkdirTool, wrapTextHandler(handleMkdir(root), formatMkdirResult))
 	} else {
-		s.AddTool(mkdirTool, mcp.NewStructuredToolHandler(handleMkdir(root)))
+		s.AddTool(mkdirTool, wrapStructuredHandler(handleMkdir(root)))
 	}
 
 	rmdirOpts := []mcp.ToolOption{
@@ -170,7 +184,7 @@ func setupServer(root string) *server.MCPServer {
 	if *compatFlag {
 		s.AddTool(rmdirTool, wrapTextHandler(handleRmdir(root), formatRmdirResult))
 	} else {
-		s.AddTool(rmdirTool, mcp.NewStructuredToolHandler(handleRmdir(root)))
+		s.AddTool(rmdirTool, wrapStructuredHandler(handleRmdir(root)))
 	}
 
 	return s


### PR DESCRIPTION
## Summary
- avoid text fallback when compat flag disabled by adding structured handler
- cover structured handler behavior with test
- ensure structured responses include an empty content array for clients expecting it

## Testing
- `go test ./services/filesystem/...`


------
https://chatgpt.com/codex/tasks/task_e_689ee1b8702483268252be8baaaf5a48