### PR TITLE
docs: simplify filesystem tool descriptions

### DIFF
--- a/services/filesystem/README.md
+++ b/services/filesystem/README.md
@@ -1,6 +1,6 @@
 # filesystem
 
-A minimal file-system server built with [MCP-Go](https://github.com/mark3labs/mcp-go). It exposes safe file operations under a configurable root for agent integration.
+A minimal file-system server built with [MCP-Go](https://github.com/mark3labs/mcp-go). It exposes safe file operations inside a chosen base folder for agent integration.
 
 ## Features
 
@@ -25,20 +25,22 @@ go install github.com/c3mb0/cemcp/services/filesystem@latest
 ## Usage
 
 ```bash
-filesystem --root /path/to/workspace
+filesystem --root /path/to/folder
 ```
+
+Use the `--root` flag to pick the base folder where all actions occur.
 
 The server communicates over stdio; see `main.go` for tool definitions and flags.
 
 ### Agent guidance
 
-- All paths are resolved relative to the configured root; do not attempt `../` escapes.
+- All paths are resolved relative to the chosen base folder; do not attempt `../` escapes.
 - `fs_glob` uses shell-style patterns with `**` for recursion. Use `fs_search` or a `**` glob for recursive work.
 - Responses are structured JSON objects; clients must parse fields instead of expecting plain text.
 
 ## Tools
 
-Each tool operates only within the configured root directory.
+Each tool operates only within the chosen base folder.
 
 ### `fs_read`
 Read a file.
@@ -96,7 +98,7 @@ Search files for text using concurrent file scanning.
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `pattern` | string | Substring or regex to find. |
-| `path` | string | Optional start directory (default root). |
+| `path` | string | Optional start directory (defaults to the base folder). |
 | `regex` | boolean | Interpret `pattern` as regex. |
 | `max_results` | number | Maximum matches to return (default 100). |
 
@@ -105,7 +107,7 @@ Match files using glob patterns. Supports `**` to span directories and runs conc
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `pattern` | string | Glob pattern relative to root. |
+| `pattern` | string | Glob pattern relative to the base folder. |
 | `max_results` | number | Maximum matches to return (default 1000). |
 
 ### Debug Logging

--- a/services/filesystem/errors.go
+++ b/services/filesystem/errors.go
@@ -9,7 +9,7 @@ import (
 var (
 	// Path errors
 	ErrPathRequired    = errors.New("path is required")
-	ErrPathOutsideRoot = errors.New("path escapes root directory")
+	ErrPathOutsideRoot = errors.New("path escapes base folder")
 	ErrPathNotFound    = errors.New("path not found")
 	ErrPathIsSymlink   = errors.New("path is a symlink")
 	ErrPathIsDirectory = errors.New("path is a directory")

--- a/services/filesystem/fs_test.go
+++ b/services/filesystem/fs_test.go
@@ -86,7 +86,7 @@ func TestSafeJoinResolveFinal(t *testing.T) {
 		t.Fatalf("symlink: %v", err)
 	}
 	if _, err := safeJoinResolveFinal(root, "badlink"); err == nil {
-		t.Fatalf("expected error for symlink outside root")
+		t.Fatalf("expected error for symlink outside base folder")
 	}
 }
 

--- a/services/filesystem/pathutil.go
+++ b/services/filesystem/pathutil.go
@@ -17,9 +17,9 @@ func mustAbs(p string) string {
 	return ap
 }
 
-// safeJoin joins root and reqPath while keeping the result within root.
+// safeJoin joins the base folder and reqPath while keeping the result within that folder.
 // It validates the parent path but does not resolve the final element.
-// For read operations where following symlinks could escape the root, use safeJoinResolveFinal.
+// For read operations where following symlinks could escape the base folder, use safeJoinResolveFinal.
 func safeJoin(root, reqPath string) (string, error) {
 	if reqPath == "" {
 		return "", errors.New("path is required")
@@ -44,7 +44,7 @@ func safeJoin(root, reqPath string) (string, error) {
 	if filepath.IsAbs(clean) {
 		finalAbs := mustAbs(clean)
 		if !strings.HasPrefix(finalAbs+string(os.PathSeparator), rootResolved+string(os.PathSeparator)) && finalAbs != rootResolved {
-			return "", fmt.Errorf("refusing to access outside root: %s", reqPath)
+			return "", fmt.Errorf("refusing to access outside base folder: %s", reqPath)
 		}
 		return finalAbs, nil
 	}
@@ -57,13 +57,13 @@ func safeJoin(root, reqPath string) (string, error) {
 	final := filepath.Join(parentResolved, base)
 	finalAbs := mustAbs(final)
 	if !strings.HasPrefix(finalAbs+string(os.PathSeparator), rootResolved+string(os.PathSeparator)) && finalAbs != rootResolved {
-		return "", fmt.Errorf("refusing to access outside root: %s", reqPath)
+		return "", fmt.Errorf("refusing to access outside base folder: %s", reqPath)
 	}
 	return finalAbs, nil
 }
 
 // safeJoinResolveFinal follows the last path element and ensures the target
-// stays within root. It guards read/peek from symlinks that jump outside.
+// stays within the base folder. It guards read/peek from symlinks that jump outside.
 func safeJoinResolveFinal(root, reqPath string) (string, error) {
 	p, err := safeJoin(root, reqPath)
 	if err != nil {
@@ -84,13 +84,13 @@ func safeJoinResolveFinal(root, reqPath string) (string, error) {
 	}
 	resolvedAbs := mustAbs(resolved)
 	if !strings.HasPrefix(resolvedAbs+string(os.PathSeparator), rootResolved+string(os.PathSeparator)) && resolvedAbs != rootResolved {
-		return "", fmt.Errorf("refusing to access symlink outside root: %s", reqPath)
+		return "", fmt.Errorf("refusing to access symlink outside base folder: %s", reqPath)
 	}
 	return resolvedAbs, nil
 }
 
-// trimUnderRoot returns p relative to root without a leading slash.
-// It normalizes separators and handles the case where root is "/".
+// trimUnderRoot returns p relative to the base folder without a leading slash.
+// It normalizes separators and handles the case where the base folder is "/".
 func trimUnderRoot(root, p string) string {
 	r := mustAbs(root)
 	r = strings.TrimSuffix(r, string(os.PathSeparator))

--- a/services/filesystem/server.go
+++ b/services/filesystem/server.go
@@ -41,7 +41,7 @@ func setupServer(root string) *server.MCPServer {
 
 	readOpts := []mcp.ToolOption{
 		mcp.WithDescription("Read a file up to a byte limit."),
-		mcp.WithString("path", mcp.Required(), mcp.Description("File path or file:// URI within root")),
+		mcp.WithString("path", mcp.Required(), mcp.Description("File path or file:// URI within base folder")),
 		mcp.WithNumber("max_bytes", mcp.Min(1), mcp.Description("Maximum bytes to return")),
 	}
 	if !*compatFlag {
@@ -127,7 +127,7 @@ func setupServer(root string) *server.MCPServer {
 	searchOpts := []mcp.ToolOption{
 		mcp.WithDescription("Search files recursively for text"),
 		mcp.WithString("pattern", mcp.Required(), mcp.Description("Substring or regex to find")),
-		mcp.WithString("path", mcp.Description("Start directory relative to root")),
+		mcp.WithString("path", mcp.Description("Start directory relative to base folder")),
 		mcp.WithBoolean("regex", mcp.Description("Interpret pattern as regular expression")),
 		mcp.WithNumber("max_results", mcp.Min(1), mcp.Description("Maximum matches to return")),
 	}
@@ -143,7 +143,7 @@ func setupServer(root string) *server.MCPServer {
 
 	globOpts := []mcp.ToolOption{
 		mcp.WithDescription("Match paths using shell-style globbing; ** enables recursion"),
-		mcp.WithString("pattern", mcp.Required(), mcp.Description("Glob pattern relative to root")),
+		mcp.WithString("pattern", mcp.Required(), mcp.Description("Glob pattern relative to base folder")),
 		mcp.WithNumber("max_results", mcp.Min(1), mcp.Description("Maximum matches to return")),
 	}
 	if !*compatFlag {

--- a/services/filesystem/types.go
+++ b/services/filesystem/types.go
@@ -19,7 +19,7 @@ type MetaFields struct {
 
 // ReadArgs defines parameters for reading files
 type ReadArgs struct {
-	Path     string `json:"path" description:"File path or file:// URI within root"`
+	Path     string `json:"path" description:"File path or file:// URI within base folder"`
 	MaxBytes int    `json:"max_bytes,omitempty" description:"Maximum bytes to return"`
 }
 
@@ -100,7 +100,7 @@ type ListArgs struct {
 
 // ListEntry represents a single file/directory entry
 type ListEntry struct {
-	Path       string `json:"path" description:"Relative path from root"`
+	Path       string `json:"path" description:"Relative path from base folder"`
 	Name       string `json:"name" description:"Base filename"`
 	Kind       string `json:"kind" description:"Type: file/dir/symlink/other"`
 	Size       int64  `json:"size" description:"Size in bytes"`
@@ -127,14 +127,14 @@ type GlobResult struct {
 // SearchArgs defines parameters for text search
 type SearchArgs struct {
 	Pattern    string `json:"pattern" description:"Text or regex pattern to find"`
-	Path       string `json:"path,omitempty" description:"Start directory relative to root"`
+	Path       string `json:"path,omitempty" description:"Start directory relative to base folder"`
 	Regex      bool   `json:"regex,omitempty" description:"Interpret pattern as regex"`
 	MaxResults int    `json:"max_results,omitempty" description:"Maximum matches to return"`
 }
 
 // SearchMatch represents a single search result
 type SearchMatch struct {
-	Path string `json:"path" description:"File path relative to root"`
+	Path string `json:"path" description:"File path relative to base folder"`
 	Line int    `json:"line" description:"Line number of match"`
 	Text string `json:"text" description:"Matching line content"`
 }


### PR DESCRIPTION
## Summary
- Clarify filesystem service README by replacing jargon like "root" with "base folder" and explaining the `--root` flag.

## Testing
- `go test ./...` *(fails: command hung and was terminated)*