### PR TITLE
Simplify directory creation and improve error reporting

### DIFF
--- a/services/filesystem/README.md
+++ b/services/filesystem/README.md
@@ -11,6 +11,7 @@ A minimal file-system server built with [MCP-Go](https://github.com/mark3labs/mc
 - Directory listing and globbing with `**` for recursion
 - Concurrent content search with substring or regex matching
 - Optional debug logging to a specified file
+- Automatic parent directory creation for write and mkdir operations
 - Structured errors with operation context and numeric codes
 - Central configuration for tunable worker pools and size limits
 - Search statistics and binary-skipping for faster scans
@@ -60,14 +61,13 @@ Read a small window of a file.
 | `max_bytes` | number | Window size in bytes (default 4&nbsp;KiB). |
 
 ### `fs_write`
-Create or modify a file.
+Create or modify a file. Parent directories are created automatically.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `path` | string | Target file path. |
 | `content` | string | Data to write. |
 | `strategy` | string | `overwrite`, `no_clobber`, `append`, `prepend`, or `replace_range` (default `overwrite`). |
-| `create_dirs` | boolean | Create parent directories (default false). |
 | `mode` | string | File mode in octal; omit to keep existing permissions. |
 | `start` | number | Start byte for `replace_range`. |
 | `end` | number | End byte (exclusive) for `replace_range`. |
@@ -109,6 +109,22 @@ Match files using glob patterns. Supports `**` to span directories and runs conc
 |-----------|------|-------------|
 | `pattern` | string | Glob pattern relative to the base folder. |
 | `max_results` | number | Maximum matches to return (default 1000). |
+
+### `fs_mkdir`
+Create a directory and any missing parent directories.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `path` | string | Directory path to create. |
+| `mode` | string | Directory mode in octal (default 0755). |
+
+### `fs_rmdir`
+Remove an empty directory or recursively delete its contents.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `path` | string | Directory to remove. |
+| `recursive` | boolean | Remove contents recursively. |
 
 ### Debug Logging
 

--- a/services/filesystem/compat_handlers_test.go
+++ b/services/filesystem/compat_handlers_test.go
@@ -22,11 +22,11 @@ func TestCompatWrapTextHandlerPropagatesErrors(t *testing.T) {
 	res, err := h(context.Background(), mcp.CallToolRequest{
 		Params: mcp.CallToolParams{Arguments: map[string]any{"path": "../outside"}},
 	})
-	if err == nil {
-		t.Fatalf("expected error, got nil (res=%v)", res)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if res != nil {
-		t.Fatalf("expected nil result on error, got %v", res)
+	if res == nil || !res.IsError {
+		t.Fatalf("expected error result, got %v", res)
 	}
 }
 

--- a/services/filesystem/fs_handlers_test.go
+++ b/services/filesystem/fs_handlers_test.go
@@ -12,7 +12,7 @@ import (
 func TestWrite_PathAndMode(t *testing.T) {
 	root := t.TempDir()
 	wr := handleWrite(root)
-	res, err := wr(context.Background(), mcp.CallToolRequest{}, WriteArgs{Path: "m/sub/file.txt", Content: "hello", Mode: "0640", CreateDirs: boolPtr(true)})
+	res, err := wr(context.Background(), mcp.CallToolRequest{}, WriteArgs{Path: "m/sub/file.txt", Content: "hello", Mode: "0640"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -27,5 +27,3 @@ func TestWrite_PathAndMode(t *testing.T) {
 		t.Fatalf("mode mismatch: %o", st.Mode()&0o777)
 	}
 }
-
-func boolPtr(b bool) *bool { return &b }

--- a/services/filesystem/fuzz_write_test.go
+++ b/services/filesystem/fuzz_write_test.go
@@ -17,9 +17,8 @@ func FuzzHandleWrite(f *testing.F) {
 		root := t.TempDir()
 		h := handleWrite(root)
 		_, _ = h(context.Background(), mcp.CallToolRequest{}, WriteArgs{
-			Path:       path,
-			Content:    string(data),
-			CreateDirs: boolPtr(true),
+			Path:    path,
+			Content: string(data),
 		})
 	})
 }

--- a/services/filesystem/helpers_test.go
+++ b/services/filesystem/helpers_test.go
@@ -224,10 +224,6 @@ func TestHandleWriteErrors(t *testing.T) {
 	if _, err := wr(context.Background(), mcp.CallToolRequest{}, WriteArgs{Path: "a.txt", Strategy: "bogus", Content: "x"}); err == nil {
 		t.Fatalf("expected strategy error")
 	}
-	if _, err := wr(context.Background(), mcp.CallToolRequest{}, WriteArgs{Path: "dir/file.txt", Content: "x", CreateDirs: boolPtr(false)}); err == nil {
-		t.Fatalf("expected missing dir error")
-	}
-
 	// append to directory should error
 	os.Mkdir(filepath.Join(root, "adir"), 0o755)
 	if _, err := wr(context.Background(), mcp.CallToolRequest{}, WriteArgs{Path: "adir", Content: "x", Strategy: strategyAppend}); err == nil {

--- a/services/filesystem/main_test.go
+++ b/services/filesystem/main_test.go
@@ -52,15 +52,17 @@ func TestReadSkipsHugeHash(t *testing.T) {
 	}
 }
 
-func TestWriteCreateDirsDefaultFalse(t *testing.T) {
+func TestWriteCreatesDirsByDefault(t *testing.T) {
 	root := t.TempDir()
 	h := handleWrite(root)
-	_, err := h(context.Background(), mcp.CallToolRequest{}, WriteArgs{
+	if _, err := h(context.Background(), mcp.CallToolRequest{}, WriteArgs{
 		Path:    "nested/dir/file.txt",
 		Content: "hi",
-	})
-	if err == nil {
-		t.Fatalf("expected error when creating dirs not opted in")
+	}); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "nested", "dir", "file.txt")); err != nil {
+		t.Fatalf("expected file to exist: %v", err)
 	}
 }
 

--- a/services/filesystem/mkdir.go
+++ b/services/filesystem/mkdir.go
@@ -16,7 +16,7 @@ func formatMkdirResult(r MkdirResult) string {
 func handleMkdir(root string) mcp.StructuredToolHandlerFunc[MkdirArgs, MkdirResult] {
 	return func(ctx context.Context, req mcp.CallToolRequest, args MkdirArgs) (MkdirResult, error) {
 		start := time.Now()
-		dprintf("-> fs_mkdir path=%q parents=%v mode=%s", args.Path, args.Parents, args.Mode)
+		dprintf("-> fs_mkdir path=%q mode=%s", args.Path, args.Mode)
 		var out MkdirResult
 		full, err := safeJoin(root, args.Path)
 		if err != nil {
@@ -38,16 +38,9 @@ func handleMkdir(root string) mcp.StructuredToolHandlerFunc[MkdirArgs, MkdirResu
 				return out, fmt.Errorf("exists and not a directory: %s", args.Path)
 			}
 		} else if os.IsNotExist(err) {
-			if args.Parents {
-				if err := os.MkdirAll(full, mode); err != nil {
-					dprintf("fs_mkdir MkdirAll error: %v", err)
-					return out, err
-				}
-			} else {
-				if err := os.Mkdir(full, mode); err != nil {
-					dprintf("fs_mkdir Mkdir error: %v", err)
-					return out, err
-				}
+			if err := os.MkdirAll(full, mode); err != nil {
+				dprintf("fs_mkdir MkdirAll error: %v", err)
+				return out, err
 			}
 			created = true
 		} else {

--- a/services/filesystem/mkdir_rmdir_test.go
+++ b/services/filesystem/mkdir_rmdir_test.go
@@ -14,7 +14,7 @@ func TestMkdirAndRmdir(t *testing.T) {
 	mk := handleMkdir(root)
 	rm := handleRmdir(root)
 
-	res, err := mk(context.Background(), mcp.CallToolRequest{}, MkdirArgs{Path: "a/b", Parents: true, Mode: "755"})
+	res, err := mk(context.Background(), mcp.CallToolRequest{}, MkdirArgs{Path: "a/b", Mode: "755"})
 	if err != nil || !res.Created {
 		t.Fatalf("mkdir failed: %+v err=%v", res, err)
 	}

--- a/services/filesystem/server.go
+++ b/services/filesystem/server.go
@@ -16,7 +16,10 @@ func wrapTextHandler[TArgs any, TResult any](h mcp.StructuredToolHandlerFunc[TAr
 		}
 		res, err := h(ctx, req, args)
 		if err != nil {
-			return nil, err
+			errResp := toErrorResponse(err)
+			out := mcp.NewToolResultStructured(errResp, errResp.Error)
+			out.IsError = true
+			return out, nil
 		}
 		return mcp.NewToolResultText(format(res)), nil
 	}
@@ -30,7 +33,10 @@ func wrapStructuredHandler[TArgs any, TResult any](h mcp.StructuredToolHandlerFu
 		}
 		res, err := h(ctx, req, args)
 		if err != nil {
-			return nil, err
+			errResp := toErrorResponse(err)
+			out := mcp.NewToolResultStructured(errResp, errResp.Error)
+			out.IsError = true
+			return out, nil
 		}
 		return &mcp.CallToolResult{StructuredContent: res}, nil
 	}
@@ -75,7 +81,6 @@ func setupServer(root string) *server.MCPServer {
 		mcp.WithString("path", mcp.Required(), mcp.Description("Target file path")),
 		mcp.WithString("content", mcp.Required(), mcp.Description("Data to write")),
 		mcp.WithString("strategy", mcp.Enum(string(strategyOverwrite), string(strategyNoClobber), string(strategyAppend), string(strategyPrepend), string(strategyReplaceRange)), mcp.Description("Write strategy: overwrite, no_clobber, append, prepend, replace_range")),
-		mcp.WithBoolean("create_dirs", mcp.Description("Create parent directories if needed")),
 		mcp.WithString("mode", mcp.Pattern("^0?[0-7]{3,4}$"), mcp.Description("File mode in octal, keep existing if omitted")),
 		mcp.WithNumber("start", mcp.Min(0), mcp.Description("Start byte for replace_range")),
 		mcp.WithNumber("end", mcp.Min(0), mcp.Description("End byte (exclusive) for replace_range")),
@@ -159,7 +164,6 @@ func setupServer(root string) *server.MCPServer {
 	mkdirOpts := []mcp.ToolOption{
 		mcp.WithDescription("Create a directory"),
 		mcp.WithString("path", mcp.Required(), mcp.Description("Directory path to create")),
-		mcp.WithBoolean("parents", mcp.Description("Create parent directories if needed")),
 		mcp.WithString("mode", mcp.Pattern("^0?[0-7]{3,4}$"), mcp.Description("Directory mode in octal")),
 	}
 	if !*compatFlag {

--- a/services/filesystem/types.go
+++ b/services/filesystem/types.go
@@ -53,13 +53,12 @@ type PeekResult struct {
 
 // WriteArgs defines parameters for writing files
 type WriteArgs struct {
-	Path       string        `json:"path" description:"Target file path"`
-	Content    string        `json:"content" description:"Data to write"`
-	Strategy   writeStrategy `json:"strategy,omitempty" description:"Write strategy: overwrite, no_clobber, append, prepend, replace_range"`
-	CreateDirs *bool         `json:"create_dirs,omitempty" description:"Create parent directories if needed"`
-	Mode       string        `json:"mode,omitempty" description:"File mode in octal, e.g. 0644"`
-	Start      *int          `json:"start,omitempty" description:"Start byte for replace_range strategy"`
-	End        *int          `json:"end,omitempty" description:"End byte (exclusive) for replace_range"`
+	Path     string        `json:"path" description:"Target file path"`
+	Content  string        `json:"content" description:"Data to write"`
+	Strategy writeStrategy `json:"strategy,omitempty" description:"Write strategy: overwrite, no_clobber, append, prepend, replace_range"`
+	Mode     string        `json:"mode,omitempty" description:"File mode in octal, e.g. 0644"`
+	Start    *int          `json:"start,omitempty" description:"Start byte for replace_range strategy"`
+	End      *int          `json:"end,omitempty" description:"End byte (exclusive) for replace_range"`
 }
 
 // WriteResult contains file write operation results
@@ -147,9 +146,8 @@ type SearchResult struct {
 
 // MkdirArgs defines parameters for creating directories
 type MkdirArgs struct {
-	Path    string `json:"path" description:"Directory path to create"`
-	Parents bool   `json:"parents,omitempty" description:"Create parent directories if needed"`
-	Mode    string `json:"mode,omitempty" description:"Directory mode in octal"`
+	Path string `json:"path" description:"Directory path to create"`
+	Mode string `json:"mode,omitempty" description:"Directory mode in octal"`
 }
 
 // MkdirResult contains directory creation results

--- a/services/filesystem/write.go
+++ b/services/filesystem/write.go
@@ -24,15 +24,9 @@ func handleWrite(root string) mcp.StructuredToolHandlerFunc[WriteArgs, WriteResu
 			dprintf("fs_write error: %v", err)
 			return res, err
 		}
-		if args.CreateDirs == nil {
-			b := false
-			args.CreateDirs = &b
-		}
-		if *args.CreateDirs {
-			if err := ensureParent(full); err != nil {
-				dprintf("fs_write error: %v", err)
-				return res, err
-			}
+		if err := ensureParent(full); err != nil {
+			dprintf("fs_write error: %v", err)
+			return res, err
 		}
 		mode, err := parseMode(args.Mode)
 		if err != nil {


### PR DESCRIPTION
## Summary
- remove `create_dirs` and `parents` options so write and mkdir always create parent folders
- surface friendly tool error responses
- document mkdir/rmdir tools and auto directory creation

## Testing
- `go test ./services/filesystem`

------
https://chatgpt.com/codex/tasks/task_e_68a5b0292b1c83268f3e9371a6304374