### PR TITLE
feat: parse numeric inputs in summaryForAlgorithm

### DIFF
--- a/services/filesystem/algorithm_summary.go
+++ b/services/filesystem/algorithm_summary.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+// summaryForAlgorithm converts algorithm-specific numeric values into float64.
+// It accepts float64, json.Number, and string representations of numbers.
+// For strings and json.Number values, strconv.ParseFloat is used to support
+// wider client inputs.
+func summaryForAlgorithm(v interface{}) float64 {
+	switch val := v.(type) {
+	case float64:
+		return val
+	case json.Number:
+		if f, err := val.Float64(); err == nil {
+			return f
+		}
+		if f, err := strconv.ParseFloat(val.String(), 64); err == nil {
+			return f
+		}
+	case string:
+		if f, err := strconv.ParseFloat(val, 64); err == nil {
+			return f
+		}
+	}
+	return 0
+}

--- a/services/filesystem/algorithm_summary_test.go
+++ b/services/filesystem/algorithm_summary_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSummaryForAlgorithm(t *testing.T) {
+	tests := []struct {
+		name  string
+		input interface{}
+		want  float64
+	}{
+		{"float", 1.23, 1.23},
+		{"jsonNumber", json.Number("4.56"), 4.56},
+		{"string", "7.89", 7.89},
+		{"invalidString", "not-a-number", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := summaryForAlgorithm(tt.input)
+			if got != tt.want {
+				t.Fatalf("summaryForAlgorithm(%v)=%v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- allow `summaryForAlgorithm` to accept `json.Number` and string inputs by parsing with `strconv.ParseFloat`
- extend `summaryForAlgorithm` tests with cases for `json.Number`, string inputs, and invalid strings

## Testing
- `go test algorithm_summary_test.go algorithm_summary.go`
- `go test ./...` *(fails: command hangs, unable to complete)*

------
https://chatgpt.com/codex/tasks/task_e_68a64abf253c83268225bfced71c8ef4