### PR TITLE
Add debugging session tracking tools

### DIFF
--- a/services/filesystem/debugsession.go
+++ b/services/filesystem/debugsession.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+const maxDebugSessions = 20
+
+// DebugSession represents a recorded debugging attempt.
+type DebugSession struct {
+	ID         string `json:"id"`
+	Approach   string `json:"approach"`
+	Resolution string `json:"resolution"`
+	Status     string `json:"status"`
+}
+
+var (
+	dbgMu       sync.Mutex
+	dbgSessions = make(map[string]*DebugSession)
+	dbgOrder    []string
+)
+
+// DebuggingApproachArgs are inputs for the debuggingapproach tool.
+type DebuggingApproachArgs struct {
+	SessionID  string `json:"session"`
+	Approach   string `json:"approach"`
+	Resolution string `json:"resolution"`
+}
+
+// DebuggingApproachResult is returned from the debuggingapproach tool.
+type DebuggingApproachResult struct {
+	SessionID string `json:"session"`
+	Status    string `json:"status"`
+	Message   string `json:"message"`
+}
+
+// handleDebuggingApproach records a debugging session and marks it complete or incomplete.
+func handleDebuggingApproach() mcp.StructuredToolHandlerFunc[DebuggingApproachArgs, DebuggingApproachResult] {
+	return func(ctx context.Context, req mcp.CallToolRequest, args DebuggingApproachArgs) (DebuggingApproachResult, error) {
+		dbgMu.Lock()
+		defer dbgMu.Unlock()
+
+		id := args.SessionID
+		if id == "" {
+			id = uuid.NewString()
+		}
+
+		status := "complete"
+		msg := "Debugging session recorded."
+		if strings.TrimSpace(args.Resolution) == "" {
+			status = "incomplete"
+			msg = "Resolution is empty; add more steps before finishing."
+		}
+
+		if _, ok := dbgSessions[id]; !ok {
+			if len(dbgOrder) >= maxDebugSessions {
+				oldest := dbgOrder[0]
+				dbgOrder = dbgOrder[1:]
+				delete(dbgSessions, oldest)
+			}
+			dbgOrder = append(dbgOrder, id)
+		}
+
+		dbgSessions[id] = &DebugSession{
+			ID:         id,
+			Approach:   args.Approach,
+			Resolution: args.Resolution,
+			Status:     status,
+		}
+
+		return DebuggingApproachResult{SessionID: id, Status: status, Message: msg}, nil
+	}
+}
+
+// PendingDebugResult lists unresolved debugging sessions.
+type PendingDebugResult struct {
+	Sessions []DebugSession `json:"sessions"`
+}
+
+// handlePendingDebug returns sessions that are incomplete.
+func handlePendingDebug() mcp.StructuredToolHandlerFunc[struct{}, PendingDebugResult] {
+	return func(ctx context.Context, req mcp.CallToolRequest, _ struct{}) (PendingDebugResult, error) {
+		dbgMu.Lock()
+		defer dbgMu.Unlock()
+		res := PendingDebugResult{}
+		for _, id := range dbgOrder {
+			if s, ok := dbgSessions[id]; ok && s.Status != "complete" {
+				res.Sessions = append(res.Sessions, *s)
+			}
+		}
+		return res, nil
+	}
+}

--- a/services/filesystem/debugsession_test.go
+++ b/services/filesystem/debugsession_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func resetDebugSessions() {
+	dbgMu.Lock()
+	defer dbgMu.Unlock()
+	dbgSessions = make(map[string]*DebugSession)
+	dbgOrder = nil
+}
+
+func TestDebuggingApproachIncomplete(t *testing.T) {
+	resetDebugSessions()
+	h := handleDebuggingApproach()
+	res, err := h(context.Background(), mcp.CallToolRequest{}, DebuggingApproachArgs{Approach: "step", Resolution: ""})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != "incomplete" {
+		t.Fatalf("expected status incomplete, got %s", res.Status)
+	}
+	p := handlePendingDebug()
+	pending, err := p(context.Background(), mcp.CallToolRequest{}, struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pending.Sessions) != 1 {
+		t.Fatalf("expected 1 pending session, got %d", len(pending.Sessions))
+	}
+}
+
+func TestDebuggingApproachComplete(t *testing.T) {
+	resetDebugSessions()
+	h := handleDebuggingApproach()
+	res, err := h(context.Background(), mcp.CallToolRequest{}, DebuggingApproachArgs{Approach: "step", Resolution: "done"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != "complete" {
+		t.Fatalf("expected status complete, got %s", res.Status)
+	}
+	p := handlePendingDebug()
+	pending, err := p(context.Background(), mcp.CallToolRequest{}, struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pending.Sessions) != 0 {
+		t.Fatalf("expected 0 pending sessions, got %d", len(pending.Sessions))
+	}
+}

--- a/services/filesystem/go.mod
+++ b/services/filesystem/go.mod
@@ -4,13 +4,13 @@ go 1.24.5
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.0.2
+	github.com/google/uuid v1.6.0
 	github.com/mark3labs/mcp-go v0.37.0
 )
 
 require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/spf13/cast v1.7.1 // indirect

--- a/services/filesystem/server.go
+++ b/services/filesystem/server.go
@@ -196,5 +196,26 @@ func setupServer(root string) *server.MCPServer {
 		s.AddTool(rmdirTool, wrapStructuredHandler(handleRmdir(root)))
 	}
 
+	dbgApproachOpts := []mcp.ToolOption{
+		mcp.WithDescription("Record debugging approach and resolution"),
+		mcp.WithString("session", mcp.Description("Existing session identifier")),
+		mcp.WithString("approach", mcp.Required(), mcp.Description("Debugging steps taken")),
+		mcp.WithString("resolution", mcp.Description("Outcome or fix applied")),
+	}
+	if !*compatFlag {
+		dbgApproachOpts = append(dbgApproachOpts, mcp.WithOutputSchema[DebuggingApproachResult]())
+	}
+	dbgApproachTool := mcp.NewTool("debuggingapproach", dbgApproachOpts...)
+	s.AddTool(dbgApproachTool, wrapStructuredHandler(handleDebuggingApproach()))
+
+	pendingOpts := []mcp.ToolOption{
+		mcp.WithDescription("List unresolved debugging sessions"),
+	}
+	if !*compatFlag {
+		pendingOpts = append(pendingOpts, mcp.WithOutputSchema[PendingDebugResult]())
+	}
+	pendingTool := mcp.NewTool("pendingdebug", pendingOpts...)
+	s.AddTool(pendingTool, wrapStructuredHandler(handlePendingDebug()))
+
 	return s
 }


### PR DESCRIPTION
## Summary
- track debugging sessions with automatic incomplete status when resolution missing
- expose `pendingdebug` tool to list unfinished sessions and enforce a session limit

## Testing
- `go mod tidy`
- `go test ./...` in `services/filesystem`

------
https://chatgpt.com/codex/tasks/task_e_68a64bfb90e4832688cdda24599e4946