### PR TITLE
feat: add stochastic thinking service

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,3 +1,6 @@
 go 1.24.5
 
-use ./services/filesystem
+use (
+	./services/filesystem
+	./services/stochastic-thinking
+)

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,1 @@
+github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/services/stochastic-thinking/go.mod
+++ b/services/stochastic-thinking/go.mod
@@ -1,0 +1,4 @@
+module github.com/example/stochastic-thinking
+
+go 1.24
+

--- a/services/stochastic-thinking/server.go
+++ b/services/stochastic-thinking/server.go
@@ -1,0 +1,58 @@
+package stochastic
+
+import "fmt"
+
+type Algorithm string
+
+const (
+	AlgorithmMonteCarlo Algorithm = "monte_carlo"
+	AlgorithmRandomWalk Algorithm = "random_walk"
+)
+
+type MonteCarloParams struct {
+	Iterations int `json:"iterations"`
+}
+
+type RandomWalkParams struct {
+	Steps int `json:"steps"`
+}
+
+type Request struct {
+	Algorithm  Algorithm         `json:"algorithm"`
+	MonteCarlo *MonteCarloParams `json:"monteCarlo,omitempty"`
+	RandomWalk *RandomWalkParams `json:"randomWalk,omitempty"`
+}
+
+type Response struct {
+	Summary   string `json:"summary"`
+	NextSteps string `json:"nextSteps"`
+}
+
+func Run(req Request) (Response, error) {
+	switch req.Algorithm {
+	case AlgorithmMonteCarlo:
+		if req.MonteCarlo == nil {
+			return Response{}, fmt.Errorf("missing parameters for %s", req.Algorithm)
+		}
+		summary, err := summaryForAlgorithm(req.Algorithm, *req.MonteCarlo)
+		if err != nil {
+			return Response{}, err
+		}
+		return Response{Summary: summary, NextSteps: "Consider adjusting iterations or trying another algorithm."}, nil
+	case AlgorithmRandomWalk:
+		if req.RandomWalk == nil {
+			return Response{}, fmt.Errorf("missing parameters for %s", req.Algorithm)
+		}
+		summary, err := summaryForAlgorithm(req.Algorithm, *req.RandomWalk)
+		if err != nil {
+			return Response{}, err
+		}
+		return Response{Summary: summary, NextSteps: "Try exploring a different path or modifying step count."}, nil
+	default:
+		return Response{}, fmt.Errorf("unsupported algorithm %s", req.Algorithm)
+	}
+}
+
+func summaryForAlgorithm(algo Algorithm, params any) (string, error) {
+	return fmt.Sprintf("%s algorithm executed", algo), nil
+}

--- a/services/stochastic-thinking/server_test.go
+++ b/services/stochastic-thinking/server_test.go
@@ -1,0 +1,23 @@
+package stochastic
+
+import "testing"
+
+func TestRunMissingParams(t *testing.T) {
+	_, err := Run(Request{Algorithm: AlgorithmMonteCarlo})
+	if err == nil {
+		t.Fatalf("expected error for missing params")
+	}
+}
+
+func TestRunSuccess(t *testing.T) {
+	resp, err := Run(Request{
+		Algorithm:  AlgorithmMonteCarlo,
+		MonteCarlo: &MonteCarloParams{Iterations: 10},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.NextSteps == "" {
+		t.Fatalf("expected next steps")
+	}
+}


### PR DESCRIPTION
## Summary
- introduce stochastic-thinking service with structured per-algorithm parameters
- validate required parameters before algorithm summary
- return next steps guidance alongside algorithm summaries

## Testing
- `go test -run Test -v` in services/stochastic-thinking
- `go test ./... -run Test -count=1` in services/filesystem


------
https://chatgpt.com/codex/tasks/task_e_68a64c00d28c8326af1966ca75067a94