### PR TITLE
Add retractthought tool and documentation

### DIFF
--- a/services/clear-thought/README.md
+++ b/services/clear-thought/README.md
@@ -1,0 +1,19 @@
+# clear-thought
+
+A lightweight session memory service built with [MCP-Go](https://github.com/mark3labs/mcp-go). It tracks sequential thoughts, mental models, and debugging approaches for agents.
+
+## Tools
+
+- `sequentialthinking` – record a thought with branching and revision metadata.
+- `retractthought` – remove the most recent thought from session memory.
+- `mentalmodel` – log a mental model used to analyze a problem.
+- `debuggingapproach` – capture a systematic debugging session.
+
+## Retract thought use cases
+
+Typical scenarios where `retractthought` is helpful:
+
+- Undo a mistaken or obsolete thought before proceeding.
+- Free capacity when the session approaches its thought limit.
+- Backtrack after exploring an unproductive line of reasoning.
+


### PR DESCRIPTION
## Summary
- support retracting the most recent thought with a new `retractthought` tool
- expose updated totals and remaining capacity after a retraction
- document common use cases for the `clear-thought` service

## Testing
- `go test ./...` (in services/clear-thought) [no test files]
- `go test ./...` (in services/filesystem)
- `go test ./...` (in services/stochastic-thinking) [no test files]


------
https://chatgpt.com/codex/tasks/task_e_68a65123afbc832684d1366cb13146f1