### PR TITLE
Add retrieval tools for clear-thought service

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository is organized as a Go monorepo containing independent services an
 
 - `services/`: standalone services
   - [`filesystem`](services/filesystem/): a minimal file-system server built with [MCP-Go](https://github.com/mark3labs/mcp-go)
+  - [`clear-thought`](services/clear-thought/): session-based reasoning tools for thoughts, mental models, and debugging
 - `pkg/`: reusable Go packages shared across services
 
 ## Development

--- a/services/clear-thought/README.md
+++ b/services/clear-thought/README.md
@@ -1,0 +1,14 @@
+# clear-thought
+
+A minimal server for managing sequential thinking, mental models, and debugging approaches.
+
+## Tools
+
+- `sequentialthinking` – process a stream of thoughts with branching and revision support.
+- `getbranch` – retrieve the sequence of thoughts for a specific branch.
+- `mentalmodel` – record the use of a mental model to analyze a problem.
+- `debuggingapproach` – record a systematic debugging session.
+- `getthoughts` – list stored thoughts. Optional `offset` and `limit` parameters paginate results.
+- `getmentalmodels` – list recorded mental models. Supports `offset` and `limit`.
+- `getdebuggingsessions` – list recorded debugging sessions. Supports `offset` and `limit`.
+

--- a/services/clear-thought/server.go
+++ b/services/clear-thought/server.go
@@ -115,6 +115,9 @@ func setupServer() *server.MCPServer {
 	registerGetBranch(s, session)
 	registerMentalModel(s, session)
 	registerDebuggingApproach(s, session)
+	registerGetThoughts(s, session)
+	registerGetMentalModels(s, session)
+	registerGetDebuggingSessions(s, session)
 
 	return s
 }
@@ -301,6 +304,144 @@ func registerDebuggingApproach(srv *server.MCPServer, state *SessionState) {
 				"totalDebuggingApproaches": len(state.GetDebuggingSessions()),
 				"recentApproaches":         recent,
 			},
+		}
+		b, _ := json.MarshalIndent(res, "", "  ")
+		return mcp.NewToolResultText(string(b)), nil
+	})
+}
+
+func registerGetThoughts(srv *server.MCPServer, state *SessionState) {
+	tool := mcp.NewTool(
+		"getthoughts",
+		mcp.WithDescription("Retrieve stored thoughts with optional pagination"),
+		mcp.WithNumber("offset", mcp.Description("Starting index")),
+		mcp.WithNumber("limit", mcp.Description("Maximum number of thoughts to return")),
+	)
+
+	srv.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		var args struct {
+			Offset *int `json:"offset"`
+			Limit  *int `json:"limit"`
+		}
+		if err := req.BindArguments(&args); err != nil {
+			errResp := map[string]any{"error": err.Error(), "status": "failed"}
+			b, _ := json.MarshalIndent(errResp, "", "  ")
+			out := mcp.NewToolResultText(string(b))
+			out.IsError = true
+			return out, nil
+		}
+
+		all := state.GetThoughts()
+		off := 0
+		if args.Offset != nil && *args.Offset > 0 {
+			off = *args.Offset
+		}
+		if off > len(all) {
+			off = len(all)
+		}
+		lim := len(all) - off
+		if args.Limit != nil && *args.Limit >= 0 && *args.Limit < lim {
+			lim = *args.Limit
+		}
+		items := all[off : off+lim]
+
+		res := map[string]any{
+			"total":    len(all),
+			"offset":   off,
+			"limit":    lim,
+			"thoughts": items,
+		}
+		b, _ := json.MarshalIndent(res, "", "  ")
+		return mcp.NewToolResultText(string(b)), nil
+	})
+}
+
+func registerGetMentalModels(srv *server.MCPServer, state *SessionState) {
+	tool := mcp.NewTool(
+		"getmentalmodels",
+		mcp.WithDescription("Retrieve stored mental models with optional pagination"),
+		mcp.WithNumber("offset", mcp.Description("Starting index")),
+		mcp.WithNumber("limit", mcp.Description("Maximum number of models to return")),
+	)
+
+	srv.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		var args struct {
+			Offset *int `json:"offset"`
+			Limit  *int `json:"limit"`
+		}
+		if err := req.BindArguments(&args); err != nil {
+			errResp := map[string]any{"error": err.Error(), "status": "failed"}
+			b, _ := json.MarshalIndent(errResp, "", "  ")
+			out := mcp.NewToolResultText(string(b))
+			out.IsError = true
+			return out, nil
+		}
+
+		all := state.GetMentalModels()
+		off := 0
+		if args.Offset != nil && *args.Offset > 0 {
+			off = *args.Offset
+		}
+		if off > len(all) {
+			off = len(all)
+		}
+		lim := len(all) - off
+		if args.Limit != nil && *args.Limit >= 0 && *args.Limit < lim {
+			lim = *args.Limit
+		}
+		items := all[off : off+lim]
+
+		res := map[string]any{
+			"total":        len(all),
+			"offset":       off,
+			"limit":        lim,
+			"mentalModels": items,
+		}
+		b, _ := json.MarshalIndent(res, "", "  ")
+		return mcp.NewToolResultText(string(b)), nil
+	})
+}
+
+func registerGetDebuggingSessions(srv *server.MCPServer, state *SessionState) {
+	tool := mcp.NewTool(
+		"getdebuggingsessions",
+		mcp.WithDescription("Retrieve stored debugging sessions with optional pagination"),
+		mcp.WithNumber("offset", mcp.Description("Starting index")),
+		mcp.WithNumber("limit", mcp.Description("Maximum number of sessions to return")),
+	)
+
+	srv.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		var args struct {
+			Offset *int `json:"offset"`
+			Limit  *int `json:"limit"`
+		}
+		if err := req.BindArguments(&args); err != nil {
+			errResp := map[string]any{"error": err.Error(), "status": "failed"}
+			b, _ := json.MarshalIndent(errResp, "", "  ")
+			out := mcp.NewToolResultText(string(b))
+			out.IsError = true
+			return out, nil
+		}
+
+		all := state.GetDebuggingSessions()
+		off := 0
+		if args.Offset != nil && *args.Offset > 0 {
+			off = *args.Offset
+		}
+		if off > len(all) {
+			off = len(all)
+		}
+		lim := len(all) - off
+		if args.Limit != nil && *args.Limit >= 0 && *args.Limit < lim {
+			lim = *args.Limit
+		}
+		items := all[off : off+lim]
+
+		res := map[string]any{
+			"total":             len(all),
+			"offset":            off,
+			"limit":             lim,
+			"debuggingSessions": items,
 		}
 		b, _ := json.MarshalIndent(res, "", "  ")
 		return mcp.NewToolResultText(string(b)), nil


### PR DESCRIPTION
## Summary
- add paginated retrieval tools for thoughts, mental models, and debugging sessions
- register new tools in the clear-thought server and document them

## Testing
- `GOPROXY=direct go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68a657731dcc832696515c71a458bca5