### PR TITLE
Validate stochastic algorithm parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository is organized as a Go monorepo containing independent services an
 - `services/`: standalone services
   - [`filesystem`](services/filesystem/): a minimal file-system server built with [MCP-Go](https://github.com/mark3labs/mcp-go)
   - [`clear-thought`](services/clear-thought/): session-based reasoning tools for thoughts, mental models, and debugging
+  - [`stochastic-thinking`](services/stochastic-thinking/): apply stochastic algorithms such as MDPs or MCTS
 - `pkg/`: reusable Go packages shared across services
 
 ## Development

--- a/services/stochastic-thinking/README.md
+++ b/services/stochastic-thinking/README.md
@@ -1,0 +1,22 @@
+# Stochastic Thinking Service
+
+`stochasticalgorithm` applies several probabilistic algorithms to decision problems.
+
+## Algorithms and required parameters
+
+| Algorithm | Required parameters |
+|-----------|--------------------|
+| `mdp`     | `gamma`, `states` |
+| `mcts`    | `simulations`, `explorationConstant` |
+| `bandit`  | `strategy`, `epsilon` |
+| `bayesian`| `acquisitionFunction` |
+| `hmm`     | `algorithm` |
+
+## Response fields
+
+The tool returns additional fields to help validate requests:
+
+- `missingParameters` – parameters required for the selected algorithm that were not provided
+- `unknownParameters` – parameters supplied in the request that are not recognized for the algorithm
+
+If either list is non-empty, `status` will be set to `failed` and no summary is produced.


### PR DESCRIPTION
## Summary
- validate algorithm parameter keys per algorithm and expose missing/unknown parameter details
- add README explaining required parameters and validation fields for stochastic-thinking service
- document stochastic-thinking service in repo overview

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a65b2355608326a9794cbaf7396ed5