### PR TITLE
Add session status summary tool

### DIFF
--- a/services/clear-thought/README.md
+++ b/services/clear-thought/README.md
@@ -11,4 +11,5 @@ A minimal server for managing sequential thinking, mental models, and debugging 
 - `getthoughts` – list stored thoughts. Optional `offset` and `limit` parameters paginate results.
 - `getmentalmodels` – list recorded mental models. Supports `offset` and `limit`.
 - `getdebuggingsessions` – list recorded debugging sessions. Supports `offset` and `limit`.
+- `sessioncontext` – summary of counts and recent entries with remaining thought capacity. Helpful for a quick status update when reasoning becomes convoluted.
 


### PR DESCRIPTION
## Summary
- add `sessioncontext` tool to expose counts, recent entries, and remaining thought capacity
- document `sessioncontext` for quick status updates when reasoning gets complex

## Testing
- `gofmt -w services/clear-thought/server.go`
- `go vet ./...`
- `go test ./...` in `services/clear-thought`


------
https://chatgpt.com/codex/tasks/task_e_68a65bb4f6108326bb8d5bfe6c5a10f9