### PR TITLE
feat(clear-thought): expose session trim statistics

### DIFF
--- a/services/clear-thought/go.mod
+++ b/services/clear-thought/go.mod
@@ -1,0 +1,3 @@
+module github.com/c3mb0/cemcp/services/clear-thought
+
+go 1.24.5

--- a/services/clear-thought/server.go
+++ b/services/clear-thought/server.go
@@ -1,0 +1,37 @@
+package clearthought
+
+// Session represents a collection of thoughts with related context that lives
+// only in memory. Mental models and debugging sessions are kept separate from
+// the trimming logic.
+type Session struct {
+	Thoughts      []string `json:"thoughts"`
+	MentalModels  []string `json:"mental_models"`
+	DebugSessions []string `json:"debug_sessions"`
+}
+
+// TrimStats reports how many thoughts were removed and how many remain after
+// trimming a session.
+type TrimStats struct {
+	Removed   int `json:"removed"`
+	Remaining int `json:"remaining"`
+}
+
+// TrimSession keeps only the most recent keepLast thoughts. Mental models and
+// debugging sessions are left untouched. A negative keepLast results in all
+// thoughts being removed. The returned TrimStats include counts of removed and
+// remaining thoughts.
+func TrimSession(s *Session, keepLast int) TrimStats {
+	if s == nil {
+		return TrimStats{}
+	}
+	if keepLast < 0 {
+		keepLast = 0
+	}
+	total := len(s.Thoughts)
+	removed := 0
+	if total > keepLast {
+		removed = total - keepLast
+		s.Thoughts = append([]string(nil), s.Thoughts[total-keepLast:]...)
+	}
+	return TrimStats{Removed: removed, Remaining: len(s.Thoughts)}
+}

--- a/services/clear-thought/server_test.go
+++ b/services/clear-thought/server_test.go
@@ -1,0 +1,28 @@
+package clearthought
+
+import "testing"
+
+func TestTrimSession(t *testing.T) {
+	s := &Session{
+		Thoughts:      []string{"a", "b", "c", "d"},
+		MentalModels:  []string{"m1"},
+		DebugSessions: []string{"d1"},
+	}
+
+	stats := TrimSession(s, 2)
+	if stats.Removed != 2 {
+		t.Fatalf("expected 2 removed, got %d", stats.Removed)
+	}
+	if stats.Remaining != 2 {
+		t.Fatalf("expected 2 remaining, got %d", stats.Remaining)
+	}
+	if len(s.Thoughts) != 2 || s.Thoughts[0] != "c" || s.Thoughts[1] != "d" {
+		t.Fatalf("thoughts not trimmed correctly: %v", s.Thoughts)
+	}
+	if len(s.MentalModels) != 1 || s.MentalModels[0] != "m1" {
+		t.Fatalf("mental models were modified: %v", s.MentalModels)
+	}
+	if len(s.DebugSessions) != 1 || s.DebugSessions[0] != "d1" {
+		t.Fatalf("debug sessions were modified: %v", s.DebugSessions)
+	}
+}


### PR DESCRIPTION
## Summary
- add `TrimSession` helper to prune older thoughts while retaining mental models and debug sessions
- update tests to cover trimming and stat reporting

## Testing
- `cd services/clear-thought && GOWORK=off go vet ./...`
- `cd services/filesystem && GOWORK=off go vet ./...`
- `cd services/clear-thought && GOWORK=off go test ./...`
- `cd services/filesystem && GOWORK=off go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a6511f6f18832689ae3cd730c2c5d8