### PR TITLE
enforce sequential thinking invariants

### DIFF
--- a/services/clear-thought/server.go
+++ b/services/clear-thought/server.go
@@ -146,6 +146,32 @@ func registerSequentialThinking(srv *server.MCPServer, state *SessionState) {
 			out.IsError = true
 			return out, nil
 		}
+		expected := len(state.GetThoughts()) + 1
+		if args.ThoughtNumber != expected {
+			errResp := map[string]any{
+				"error":                 fmt.Sprintf("thoughtNumber must be %d but got %d", expected, args.ThoughtNumber),
+				"expectedThoughtNumber": expected,
+				"status":                "failed",
+			}
+			b, _ := json.MarshalIndent(errResp, "", "  ")
+			out := mcp.NewToolResultText(string(b))
+			out.IsError = true
+			return out, nil
+		}
+		if args.IsRevision != nil && args.RevisesThought == nil {
+			errResp := map[string]any{"error": "revisesThought is required when isRevision is set", "status": "failed"}
+			b, _ := json.MarshalIndent(errResp, "", "  ")
+			out := mcp.NewToolResultText(string(b))
+			out.IsError = true
+			return out, nil
+		}
+		if args.BranchFromThought != nil && args.BranchID == nil {
+			errResp := map[string]any{"error": "branchId is required when branchFromThought is provided", "status": "failed"}
+			b, _ := json.MarshalIndent(errResp, "", "  ")
+			out := mcp.NewToolResultText(string(b))
+			out.IsError = true
+			return out, nil
+		}
 		if args.BranchID != nil {
 			if err := state.RegisterBranch(*args.BranchID, args.BranchFromThought); err != nil {
 				errResp := map[string]any{"error": err.Error(), "status": "failed"}


### PR DESCRIPTION
## Summary
- add checks for thought sequence numbers in sequentialthinking handler
- require revisesThought or branchId when isRevision or branchFromThought is provided
- return structured error messages for invalid requests

## Testing
- `go test ./...` *(fails: directory prefix . does not contain modules listed in go.work or their selected dependencies)*
- `(cd services/clear-thought && go test ./...)`
- `(cd services/filesystem && go test ./...)`
- `(cd services/stochastic-thinking && go test ./...)`


------
https://chatgpt.com/codex/tasks/task_e_68a64bffa04c8326ba2da0ec0fa5a82a