### PR TITLE
feat: track session goals

### DIFF
--- a/services/filesystem/goals.go
+++ b/services/filesystem/goals.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// Goal represents a session goal tracked by the agent
+// description: text of the objective
+// completed: whether the goal has been completed
+// notes: optional additional notes
+
+type Goal struct {
+	Description string `json:"description"`
+	Completed   bool   `json:"completed"`
+	Notes       string `json:"notes,omitempty"`
+}
+
+// SessionState holds per-session data including goals
+
+type SessionState struct {
+	mu    sync.RWMutex
+	Goals []Goal `json:"goals"`
+}
+
+var sessionStates sync.Map // map sessionID -> *SessionState
+
+func getSessionState(ctx context.Context) *SessionState {
+	session := server.ClientSessionFromContext(ctx)
+	if session == nil {
+		return nil
+	}
+	sid := session.SessionID()
+	state, _ := sessionStates.LoadOrStore(sid, &SessionState{})
+	return state.(*SessionState)
+}
+
+// attachSessionContext adds outstanding goals to the result meta so clients are aware
+func attachSessionContext(ctx context.Context, result *mcp.CallToolResult) {
+	state := getSessionState(ctx)
+	if state == nil {
+		return
+	}
+	state.mu.RLock()
+	var pending []Goal
+	for _, g := range state.Goals {
+		if !g.Completed {
+			pending = append(pending, g)
+		}
+	}
+	state.mu.RUnlock()
+	sessionData := map[string]any{"goals": pending}
+	if result.Meta == nil {
+		result.Meta = mcp.NewMetaFromMap(map[string]any{"session": sessionData})
+		return
+	}
+	if result.Meta.AdditionalFields == nil {
+		result.Meta.AdditionalFields = make(map[string]any)
+	}
+	result.Meta.AdditionalFields["session"] = sessionData
+}
+
+type AddGoalArgs struct {
+	Description string `json:"description"`
+	Notes       string `json:"notes,omitempty"`
+}
+
+type AddGoalResult struct {
+	Index int  `json:"index"`
+	Goal  Goal `json:"goal"`
+}
+
+func formatAddGoalResult(r AddGoalResult) string {
+	return fmt.Sprintf("goal %d added", r.Index)
+}
+
+func handleAddGoal() mcp.StructuredToolHandlerFunc[AddGoalArgs, AddGoalResult] {
+	return func(ctx context.Context, req mcp.CallToolRequest, args AddGoalArgs) (AddGoalResult, error) {
+		state := getSessionState(ctx)
+		if state == nil {
+			return AddGoalResult{}, fmt.Errorf("no active session")
+		}
+		goal := Goal{Description: args.Description, Notes: args.Notes}
+		state.mu.Lock()
+		state.Goals = append(state.Goals, goal)
+		idx := len(state.Goals) - 1
+		state.mu.Unlock()
+		return AddGoalResult{Index: idx, Goal: goal}, nil
+	}
+}
+
+type UpdateGoalArgs struct {
+	Index     int     `json:"index"`
+	Completed *bool   `json:"completed,omitempty"`
+	Notes     *string `json:"notes,omitempty"`
+}
+
+type UpdateGoalResult struct {
+	Index int  `json:"index"`
+	Goal  Goal `json:"goal"`
+}
+
+func formatUpdateGoalResult(r UpdateGoalResult) string {
+	return fmt.Sprintf("goal %d updated", r.Index)
+}
+
+func handleUpdateGoal() mcp.StructuredToolHandlerFunc[UpdateGoalArgs, UpdateGoalResult] {
+	return func(ctx context.Context, req mcp.CallToolRequest, args UpdateGoalArgs) (UpdateGoalResult, error) {
+		state := getSessionState(ctx)
+		if state == nil {
+			return UpdateGoalResult{}, fmt.Errorf("no active session")
+		}
+		state.mu.Lock()
+		defer state.mu.Unlock()
+		if args.Index < 0 || args.Index >= len(state.Goals) {
+			return UpdateGoalResult{}, fmt.Errorf("invalid goal index")
+		}
+		goal := state.Goals[args.Index]
+		if args.Completed != nil {
+			goal.Completed = *args.Completed
+		}
+		if args.Notes != nil {
+			goal.Notes = *args.Notes
+		}
+		state.Goals[args.Index] = goal
+		return UpdateGoalResult{Index: args.Index, Goal: goal}, nil
+	}
+}

--- a/services/filesystem/goals_test.go
+++ b/services/filesystem/goals_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/mcptest"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// extractGoals decodes outstanding goals from the CallToolResult meta
+func extractGoals(res *mcp.CallToolResult) ([]Goal, bool) {
+	if res.Meta == nil || res.Meta.AdditionalFields == nil {
+		return nil, false
+	}
+	sessionField, ok := res.Meta.AdditionalFields["session"]
+	if !ok {
+		return nil, false
+	}
+	b, err := json.Marshal(sessionField)
+	if err != nil {
+		return nil, false
+	}
+	var state SessionState
+	if err := json.Unmarshal(b, &state); err != nil {
+		return nil, false
+	}
+	return state.Goals, true
+}
+
+func TestSessionGoalsContext(t *testing.T) {
+	srv, err := mcptest.NewServer(t,
+		server.ServerTool{Tool: mcp.NewTool("addgoal", mcp.WithOutputSchema[AddGoalResult]()), Handler: wrapStructuredHandler(handleAddGoal())},
+		server.ServerTool{Tool: mcp.NewTool("updategoal", mcp.WithOutputSchema[UpdateGoalResult]()), Handler: wrapStructuredHandler(handleUpdateGoal())},
+		server.ServerTool{Tool: mcp.NewTool("noop"), Handler: wrapStructuredHandler(func(ctx context.Context, req mcp.CallToolRequest, _ struct{}) (struct{}, error) {
+			return struct{}{}, nil
+		})},
+	)
+	if err != nil {
+		t.Fatalf("server start failed: %v", err)
+	}
+	defer srv.Close()
+
+	// Add a goal
+	_, err = srv.Client().CallTool(context.Background(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Name: "addgoal", Arguments: map[string]any{"description": "test goal"}},
+	})
+	if err != nil {
+		t.Fatalf("addgoal call failed: %v", err)
+	}
+
+	// Check session context via noop tool
+	res, err := srv.Client().CallTool(context.Background(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Name: "noop"},
+	})
+	if err != nil {
+		t.Fatalf("noop call failed: %v", err)
+	}
+	goals, ok := extractGoals(res)
+	if !ok || len(goals) != 1 || goals[0].Description != "test goal" || goals[0].Completed {
+		t.Fatalf("unexpected goals after add: %+v", goals)
+	}
+
+	// Complete the goal
+	_, err = srv.Client().CallTool(context.Background(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Name: "updategoal", Arguments: map[string]any{"index": 0, "completed": true}},
+	})
+	if err != nil {
+		t.Fatalf("updategoal call failed: %v", err)
+	}
+
+	// Verify session context is empty
+	res, err = srv.Client().CallTool(context.Background(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Name: "noop"},
+	})
+	if err != nil {
+		t.Fatalf("noop call failed: %v", err)
+	}
+	goals, _ = extractGoals(res)
+	if len(goals) != 0 {
+		t.Fatalf("expected no outstanding goals, got %#v", goals)
+	}
+}


### PR DESCRIPTION
## Summary
- track per-session goals and expose them in returned session context
- add `addgoal` and `updategoal` tools for managing goals
- propagate session context in tool wrapper responses so agents see pending goals
- guard session goal updates with mutex for concurrent safety

## Testing
- `go test ./...` (from `services/filesystem`)


------
https://chatgpt.com/codex/tasks/task_e_68a64e3bf9b0832688aa473b324cff72