### PR TITLE
Add session reset tool

### DIFF
--- a/services/clear-thought/README.md
+++ b/services/clear-thought/README.md
@@ -11,4 +11,5 @@ A minimal server for managing sequential thinking, mental models, and debugging 
 - `getthoughts` – list stored thoughts. Optional `offset` and `limit` parameters paginate results.
 - `getmentalmodels` – list recorded mental models. Supports `offset` and `limit`.
 - `getdebuggingsessions` – list recorded debugging sessions. Supports `offset` and `limit`.
+- `resetsession` – clear all stored thoughts, mental models, and debugging sessions to discard prior context.
 


### PR DESCRIPTION
## Summary
- add `Reset` method and `resetsession` tool to clear prior thoughts, models, and debugging sessions
- document `resetsession` in README so agents know to discard context

## Testing
- `go test ./...` (in services/clear-thought)


------
https://chatgpt.com/codex/tasks/task_e_68a65d1f075c8326acac6ff2c5265cd4