### PR TITLE
Support session IDs and thought limits

### DIFF
--- a/services/filesystem/README.md
+++ b/services/filesystem/README.md
@@ -33,6 +33,12 @@ Use the `--root` flag to pick the base folder where all actions occur.
 
 The server communicates over stdio; see `main.go` for tool definitions and flags.
 
+### Session configuration
+
+`filesystem` can track usage per client session. Set `MCP_SESSION_ID` or pass
+`--session-id` to label a session. Limit tool invocations by setting
+`MCP_MAX_THOUGHTS` or using `--max-thoughts` (0 means no limit).
+
 ### Agent guidance
 
 - All paths are resolved relative to the chosen base folder; do not attempt `../` escapes.

--- a/services/filesystem/config.go
+++ b/services/filesystem/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 )
 
 // Configuration constants with tunable defaults
@@ -41,7 +42,18 @@ var (
 	workersFlag     = flag.Int("workers", defaultWorkers, "number of worker threads (0=auto)")
 	maxSizeFlag     = flag.Int64("max-size", maxFileSize, "maximum file size in bytes")
 	lockTimeoutFlag = flag.Int("lock-timeout", defaultLockTimeout, "file lock timeout in seconds")
+	sessionIDFlag   = flag.String("session-id", os.Getenv("MCP_SESSION_ID"), "session identifier")
+	maxThoughtsFlag = flag.Int("max-thoughts", envInt("MCP_MAX_THOUGHTS", 0), "maximum tool calls per session (0=unlimited)")
 )
+
+func envInt(name string, def int) int {
+	if v := os.Getenv(name); v != "" {
+		if i, err := strconv.Atoi(v); err == nil {
+			return i
+		}
+	}
+	return def
+}
 
 // ServerConfig holds server configuration
 type ServerConfig struct {
@@ -51,6 +63,8 @@ type ServerConfig struct {
 	Workers     int
 	MaxFileSize int64
 	LockTimeout int
+	SessionID   string
+	MaxThoughts int
 }
 
 // LoadConfig loads configuration from flags and environment
@@ -84,6 +98,8 @@ func LoadConfig() (*ServerConfig, error) {
 		Workers:     workers,
 		MaxFileSize: *maxSizeFlag,
 		LockTimeout: *lockTimeoutFlag,
+		SessionID:   *sessionIDFlag,
+		MaxThoughts: *maxThoughtsFlag,
 	}
 
 	// Validate configuration
@@ -110,6 +126,10 @@ func (c *ServerConfig) Validate() error {
 
 	if c.LockTimeout < 1 {
 		return fmt.Errorf("lock timeout must be at least 1 second")
+	}
+
+	if c.MaxThoughts < 0 {
+		return fmt.Errorf("max thoughts must be non-negative")
 	}
 
 	return nil

--- a/services/filesystem/server.go
+++ b/services/filesystem/server.go
@@ -49,6 +49,7 @@ func wrapStructuredHandler[TArgs any, TResult any](h mcp.StructuredToolHandlerFu
 
 func setupServer(root string) *server.MCPServer {
 	s := server.NewMCPServer("fs-mcp-go", "0.1.0")
+	server.WithToolHandlerMiddleware(sessionMiddleware())(s)
 
 	readOpts := []mcp.ToolOption{
 		mcp.WithDescription("Read a file up to a byte limit."),

--- a/services/filesystem/session_state.go
+++ b/services/filesystem/session_state.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// SessionState tracks per-session usage limits.
+type SessionState struct {
+	ID          string
+	MaxThoughts int
+	mu          sync.Mutex
+	Thoughts    int
+}
+
+// sessionStateKey is used for storing SessionState in context.
+type sessionStateKey struct{}
+
+// SessionStateFromContext retrieves SessionState from context if present.
+func SessionStateFromContext(ctx context.Context) *SessionState {
+	if v, ok := ctx.Value(sessionStateKey{}).(*SessionState); ok {
+		return v
+	}
+	return nil
+}
+
+// sessionMiddleware attaches SessionState to each request and enforces limits.
+func sessionMiddleware() server.ToolHandlerMiddleware {
+	var states sync.Map
+	return func(next server.ToolHandlerFunc) server.ToolHandlerFunc {
+		return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			sid := *sessionIDFlag
+			if sid == "" {
+				if s := server.ClientSessionFromContext(ctx); s != nil {
+					sid = s.SessionID()
+				}
+			}
+			if sid == "" {
+				sid = "anonymous"
+			}
+
+			v, _ := states.LoadOrStore(sid, &SessionState{ID: sid, MaxThoughts: *maxThoughtsFlag})
+			state := v.(*SessionState)
+			ctx = context.WithValue(ctx, sessionStateKey{}, state)
+
+			state.mu.Lock()
+			defer state.mu.Unlock()
+			if state.MaxThoughts > 0 && state.Thoughts >= state.MaxThoughts {
+				return nil, fmt.Errorf("max thoughts exceeded")
+			}
+			state.Thoughts++
+			return next(ctx, req)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- allow configuring session ID and max thoughts via env vars or flags
- create per-connection SessionState middleware enforcing thought limits
- document session configuration options

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a64e7623f083268e7daebdca82a965