### PR TITLE
docs: add README for stochastic-thinking and clear-thought services

### DIFF
--- a/services/clear-thought/README.md
+++ b/services/clear-thought/README.md
@@ -1,0 +1,56 @@
+# clear-thought
+
+A clarity-oriented microservice built with [MCP-Go](https://github.com/mark3labs/mcp-go). It focuses on summarization and structural outlining.
+
+## Tools
+
+### `ct_summarize`
+Summarize a block of text.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `text` | string | yes | Content to summarize. |
+| `style` | string | no | Tone of summary (e.g., "bullet"). |
+
+**Example payload**
+
+```json
+{
+  "tool": "ct_summarize",
+  "text": "long passage",
+  "style": "bullet"
+}
+```
+
+### `ct_outline`
+Generate an outline from notes.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `text` | string | yes | Source material. |
+| `depth` | number | no | Outline depth (default 2). |
+
+**Example payload**
+
+```json
+{
+  "tool": "ct_outline",
+  "text": "notes about project milestones",
+  "depth": 3
+}
+```
+
+## Usage
+
+Run the service over stdio:
+
+```bash
+go run ./services/clear-thought/main.go --model openai:gpt-4o-mini
+```
+
+The program uses `server.ServeStdio` to exchange JSON over stdin/stdout.
+
+## Configuration
+
+- `--model` flag or `CT_MODEL` environment variable sets the model.
+- `--max-tokens` flag or `CT_MAX_TOKENS` environment variable sets the response size limit.

--- a/services/stochastic-thinking/README.md
+++ b/services/stochastic-thinking/README.md
@@ -1,0 +1,56 @@
+# stochastic-thinking
+
+A brainstorming microservice built with [MCP-Go](https://github.com/mark3labs/mcp-go). It offers lightweight tools for generating stochastic ideas and variations.
+
+## Tools
+
+### `st_brainstorm`
+Generate multiple ideas around a topic.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `topic` | string | yes | Subject to explore. |
+| `count` | number | no | Number of ideas to return (default 5). |
+
+**Example payload**
+
+```json
+{
+  "tool": "st_brainstorm",
+  "topic": "user engagement features",
+  "count": 3
+}
+```
+
+### `st_variations`
+Create variations of a statement using stochastic sampling.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `seed` | string | yes | Starting text. |
+| `temperature` | number | no | Sampling temperature (default 1.0). |
+
+**Example payload**
+
+```json
+{
+  "tool": "st_variations",
+  "seed": "launch a new product",
+  "temperature": 0.8
+}
+```
+
+## Usage
+
+Start the service over stdio:
+
+```bash
+go run ./services/stochastic-thinking/main.go --model openai:gpt-4
+```
+
+The main program calls `server.ServeStdio` and streams JSON over stdin/stdout.
+
+## Configuration
+
+- `--model` flag or `ST_MODEL` environment variable selects the backing language model.
+- `--max-tokens` flag or `ST_MAX_TOKENS` environment variable sets the response size limit.


### PR DESCRIPTION
## Summary
- add documentation for new `stochastic-thinking` service, including brainstorm and variation tools, CLI usage via `server.ServeStdio`, and configurable flags
- document `clear-thought` service with summarize and outline tools, example payloads, and environment variable options

## Testing
- `go test ./...` *(fails: directory prefix . does not contain modules listed in go.work)*

------
https://chatgpt.com/codex/tasks/task_e_68a6502dc39483269ac8d8d4c00ce422