### PR TITLE
Store stochastic summaries for later reasoning

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,6 +1,7 @@
 go 1.24.5
 
 use (
+./pkg
 ./services/filesystem
 ./services/stochastic-thinking
 ./services/clear-thought

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,0 +1,4 @@
+module github.com/c3mb0/cemcp/pkg
+
+go 1.24.5
+

--- a/pkg/stochastic/summary.go
+++ b/pkg/stochastic/summary.go
@@ -1,0 +1,40 @@
+package stochastic
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// StochasticSummary captures the outcome of a stochastic algorithm run.
+type StochasticSummary struct {
+	Algorithm string `json:"algorithm"`
+	Summary   string `json:"summary"`
+	NextSteps string `json:"nextSteps"`
+}
+
+func filePath(sessionID string) string {
+	return filepath.Join(os.TempDir(), "stochastic_"+sessionID+".json")
+}
+
+// WriteSummary persists a summary for the given session ID.
+func WriteSummary(sessionID string, s StochasticSummary) error {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filePath(sessionID), b, 0o644)
+}
+
+// ReadSummary retrieves a summary for the given session ID.
+func ReadSummary(sessionID string) (*StochasticSummary, error) {
+	b, err := os.ReadFile(filePath(sessionID))
+	if err != nil {
+		return nil, err
+	}
+	var s StochasticSummary
+	if err := json.Unmarshal(b, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}

--- a/services/clear-thought/go.mod
+++ b/services/clear-thought/go.mod
@@ -2,7 +2,10 @@ module github.com/c3mb0/cemcp/services/clear-thought
 
 go 1.24.5
 
-require github.com/mark3labs/mcp-go v0.37.0
+require (
+	github.com/c3mb0/cemcp/pkg v0.0.0
+	github.com/mark3labs/mcp-go v0.37.0
+)
 
 require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
@@ -15,3 +18,5 @@ require (
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/c3mb0/cemcp/pkg => ../../pkg

--- a/services/clear-thought/server.go
+++ b/services/clear-thought/server.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/c3mb0/cemcp/pkg/stochastic"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -231,6 +232,9 @@ func registerSequentialThinking(srv *server.MCPServer, state *SessionState) {
 		}
 		if summary != "" {
 			sessionCtx["summary"] = summary
+		}
+		if ss, err := stochastic.ReadSummary(state.SessionID()); err == nil {
+			sessionCtx["stochasticSummary"] = ss
 		}
 		res := map[string]any{
 			"thought":           args.Thought,

--- a/services/stochastic-thinking/go.mod
+++ b/services/stochastic-thinking/go.mod
@@ -2,7 +2,10 @@ module github.com/c3mb0/cemcp/services/stochastic-thinking
 
 go 1.24.5
 
-require github.com/mark3labs/mcp-go v0.37.0
+require (
+	github.com/c3mb0/cemcp/pkg v0.0.0
+	github.com/mark3labs/mcp-go v0.37.0
+)
 
 require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
@@ -15,3 +18,5 @@ require (
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/c3mb0/cemcp/pkg => ../../pkg

--- a/services/stochastic-thinking/server.go
+++ b/services/stochastic-thinking/server.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/c3mb0/cemcp/pkg/stochastic"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -87,6 +88,21 @@ Supports various algorithms including:
 
 		fmt.Fprintln(os.Stderr, formatOutput(args))
 		summary, nextSteps := summaryForAlgorithm(args)
+
+		sessionID := ""
+		if req.Params.Meta != nil {
+			if v, ok := req.Params.Meta.AdditionalFields["sessionId"].(string); ok {
+				sessionID = v
+			}
+		}
+		if sessionID != "" {
+			_ = stochastic.WriteSummary(sessionID, stochastic.StochasticSummary{
+				Algorithm: args.Algorithm,
+				Summary:   summary,
+				NextSteps: nextSteps,
+			})
+		}
+
 		res := map[string]any{
 			"algorithm": args.Algorithm,
 			"status":    "success",


### PR DESCRIPTION
## Summary
- add `StochasticSummary` shared type and simple file-backed store
- persist algorithm outcomes in `stochasticalgorithm` keyed by session
- expose stored summaries in `sequentialthinking` session context

## Testing
- `go build ./...` (services/stochastic-thinking)
- `go build ./...` (services/clear-thought)
- `go build ./...` (pkg)
- `go vet ./...` (services/stochastic-thinking)
- `go vet ./...` (services/clear-thought)


------
https://chatgpt.com/codex/tasks/task_e_68a66340b4d083268f85a60a0e505f09