### PR TITLE
Add retract thought tool

### DIFF
--- a/services/clear-thought/README.md
+++ b/services/clear-thought/README.md
@@ -12,4 +12,10 @@ A minimal server for managing sequential thinking, mental models, and debugging 
 - `getmentalmodels` – list recorded mental models. Supports `offset` and `limit`.
 - `getdebuggingsessions` – list recorded debugging sessions. Supports `offset` and `limit`.
 - `sessioncontext` – summary of counts and recent entries with remaining thought capacity. Helpful for a quick status update when reasoning becomes convoluted.
+- `retractthought` – remove the most recent thought when it becomes irrelevant or incorrect.
 
+## Typical Use Cases
+
+- Backtrack a mistaken line of reasoning by retracting the latest thought and freeing capacity for new ideas.
+- Capture and review mental models or debugging approaches used during problem solving.
+- Obtain a quick snapshot of session context when reasoning becomes complex or needs summarization.

--- a/services/clear-thought/server.go
+++ b/services/clear-thought/server.go
@@ -120,6 +120,16 @@ func (s *SessionState) GetRemainingThoughts() int {
 	return s.config.MaxThoughtsPerSession - len(s.thoughts)
 }
 
+func (s *SessionState) RetractThought() (*ThoughtData, bool) {
+	n := len(s.thoughts)
+	if n == 0 {
+		return nil, false
+	}
+	t := s.thoughts[n-1]
+	s.thoughts = s.thoughts[:n-1]
+	return &t, true
+}
+
 func (s *SessionState) AddMentalModel(m MentalModelData)   { s.mentalModels = append(s.mentalModels, m) }
 func (s *SessionState) GetMentalModels() []MentalModelData { return s.mentalModels }
 
@@ -161,6 +171,7 @@ func setupServer() *server.MCPServer {
 
 	registerSequentialThinking(s, session)
 	registerUpdateThought(s, session)
+	registerRetractThought(s, session)
 	registerGetBranch(s, session)
 	registerMentalModel(s, session)
 	registerDebuggingApproach(s, session)
@@ -303,6 +314,33 @@ func registerUpdateThought(srv *server.MCPServer, state *SessionState) {
 				"sessionId":      state.SessionID(),
 				"updatedThought": updated,
 			},
+		}
+		b, _ := json.MarshalIndent(res, "", "  ")
+		return mcp.NewToolResultText(string(b)), nil
+	})
+}
+
+func registerRetractThought(srv *server.MCPServer, state *SessionState) {
+	tool := mcp.NewTool(
+		"retractthought",
+		mcp.WithDescription("Remove the most recent thought"),
+	)
+
+	srv.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		t, ok := state.RetractThought()
+		if !ok {
+			errResp := map[string]any{"error": "no thoughts to retract", "status": "empty"}
+			b, _ := json.MarshalIndent(errResp, "", "  ")
+			out := mcp.NewToolResultText(string(b))
+			out.IsError = true
+			return out, nil
+		}
+
+		res := map[string]any{
+			"retractedThought":  t,
+			"totalThoughts":     len(state.GetThoughts()),
+			"remainingThoughts": state.GetRemainingThoughts(),
+			"status":            "success",
 		}
 		b, _ := json.MarshalIndent(res, "", "  ")
 		return mcp.NewToolResultText(string(b)), nil


### PR DESCRIPTION
## Summary
- add `retractthought` tool to remove the latest thought and report remaining capacity
- document typical use cases for clear-thought service

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68a663ccf4e08326b42bffaa216bad47