### PR TITLE
feat: warn on out-of-order thoughts

### DIFF
--- a/services/clear-thought/server.go
+++ b/services/clear-thought/server.go
@@ -210,16 +210,15 @@ func registerSequentialThinking(srv *server.MCPServer, state *SessionState) {
 			out.IsError = true
 			return out, nil
 		}
-		expected := len(state.GetThoughts()) + 1
-		if args.ThoughtNumber != expected {
-			errResp := map[string]any{
-				"error":                 fmt.Sprintf("thoughtNumber must be %d but got %d", expected, args.ThoughtNumber),
-				"expectedThoughtNumber": expected,
-				"status":                "failed",
+		expectedThoughtNumber := len(state.GetThoughts()) + 1
+		if args.ThoughtNumber != expectedThoughtNumber {
+			warnResp := map[string]any{
+				"error":                 fmt.Sprintf("thoughtNumber must be %d but got %d", expectedThoughtNumber, args.ThoughtNumber),
+				"expectedThoughtNumber": expectedThoughtNumber,
+				"status":                "out_of_order",
 			}
-			b, _ := json.MarshalIndent(errResp, "", "  ")
+			b, _ := json.MarshalIndent(warnResp, "", "  ")
 			out := mcp.NewToolResultText(string(b))
-			out.IsError = true
 			return out, nil
 		}
 		if args.IsRevision != nil && args.RevisesThought == nil {
@@ -262,17 +261,18 @@ func registerSequentialThinking(srv *server.MCPServer, state *SessionState) {
 			sessionCtx["stochasticSummary"] = ss
 		}
 		res := map[string]any{
-			"thought":           args.Thought,
-			"thoughtNumber":     args.ThoughtNumber,
-			"totalThoughts":     args.TotalThoughts,
-			"nextThoughtNeeded": args.NextThoughtNeeded,
-			"isRevision":        args.IsRevision,
-			"revisesThought":    args.RevisesThought,
-			"branchFromThought": args.BranchFromThought,
-			"branchId":          args.BranchID,
-			"needsMoreThoughts": args.NeedsMoreThoughts,
-			"status":            map[bool]string{true: "success", false: "limit_reached"}[added],
-			"sessionContext":    sessionCtx,
+			"thought":               args.Thought,
+			"thoughtNumber":         args.ThoughtNumber,
+			"expectedThoughtNumber": expectedThoughtNumber,
+			"totalThoughts":         args.TotalThoughts,
+			"nextThoughtNeeded":     args.NextThoughtNeeded,
+			"isRevision":            args.IsRevision,
+			"revisesThought":        args.RevisesThought,
+			"branchFromThought":     args.BranchFromThought,
+			"branchId":              args.BranchID,
+			"needsMoreThoughts":     args.NeedsMoreThoughts,
+			"status":                map[bool]string{true: "success", false: "limit_reached"}[added],
+			"sessionContext":        sessionCtx,
 		}
 		b, _ := json.MarshalIndent(res, "", "  ")
 		return mcp.NewToolResultText(string(b)), nil


### PR DESCRIPTION
## Summary
- compute `expectedThoughtNumber` in sequential thinking tool
- return `expectedThoughtNumber` in responses and warn with `out_of_order` status when numbers mismatch

## Testing
- `go test ./...` *(fails: pattern ./...: directory prefix . does not contain modules listed in go.work or their selected dependencies)*
- `(cd services/clear-thought && go test ./...)`
- `(cd services/filesystem && go test ./...)`
- `(cd services/stochastic-thinking && go test ./...)`
- `(cd pkg && go test ./...)`


------
https://chatgpt.com/codex/tasks/task_e_68a666a409b88326ae9300418e978da7