### PR TITLE
Add session reset tool

### DIFF
--- a/services/clear-thought/README.md
+++ b/services/clear-thought/README.md
@@ -12,6 +12,7 @@ A minimal server for managing sequential thinking, mental models, and debugging 
 - `getmentalmodels` – list recorded mental models. Supports `offset` and `limit`.
 - `getdebuggingsessions` – list recorded debugging sessions. Supports `offset` and `limit`.
 - `sessioncontext` – summary of counts and recent entries with remaining thought capacity. Helpful for a quick status update when reasoning becomes convoluted.
+- `resetsession` – clear all stored thoughts, mental models, and debugging sessions to discard prior context and restore full thought capacity.
 - `retractthought` – remove the most recent thought when it becomes irrelevant or incorrect.
 
 ## Typical Use Cases
@@ -19,3 +20,4 @@ A minimal server for managing sequential thinking, mental models, and debugging 
 - Backtrack a mistaken line of reasoning by retracting the latest thought and freeing capacity for new ideas.
 - Capture and review mental models or debugging approaches used during problem solving.
 - Obtain a quick snapshot of session context when reasoning becomes complex or needs summarization.
+- Reset the session entirely when previous context becomes irrelevant and a fresh start is required.


### PR DESCRIPTION
## Summary
- add `Reset` method and `resetsession` tool to clear-thought server
- document `resetsession` usage in README

## Testing
- `go vet ./services/clear-thought/...`
- `go test ./services/clear-thought/...`


------
https://chatgpt.com/codex/tasks/task_e_68a668da1abc8326b870ef71bd286fc9