### PR TITLE
Add hint messages to algorithm and thinking handlers

### DIFF
--- a/services/clear-thought/README.md
+++ b/services/clear-thought/README.md
@@ -4,7 +4,7 @@ A minimal server for managing sequential thinking, mental models, and debugging 
 
 ## Tools
 
-- `sequentialthinking` – process a stream of thoughts with branching and revision support.
+- `sequentialthinking` – process a stream of thoughts with branching and revision support. Responses include a `hint` with the next expected thought number.
 - `getbranch` – retrieve the sequence of thoughts for a specific branch.
 - `mentalmodel` – record the use of a mental model to analyze a problem.
 - `debuggingapproach` – record a systematic debugging session.

--- a/services/clear-thought/server.go
+++ b/services/clear-thought/server.go
@@ -282,6 +282,7 @@ func registerSequentialThinking(srv *server.MCPServer, state *SessionState) {
 			"needsMoreThoughts":     args.NeedsMoreThoughts,
 			"status":                map[bool]string{true: "success", false: "limit_reached"}[added],
 			"sessionContext":        sessionCtx,
+			"hint":                  fmt.Sprintf("Submit thought #%d if continuing.", expectedThoughtNumber),
 		}
 		b, _ := json.MarshalIndent(res, "", "  ")
 		return mcp.NewToolResultText(string(b)), nil

--- a/services/stochastic-thinking/README.md
+++ b/services/stochastic-thinking/README.md
@@ -23,5 +23,6 @@ The tool returns the following fields:
 - `summary` – brief description of what the algorithm accomplished
 - `nextSteps` – suggestion for how to proceed after the algorithm run
 - `hasResult` – whether a `result` field was provided in the request
+- `hint` – suggests rerunning with a `result` to verify outcomes
 
 `status` will be set to `success` when all required parameters are present, otherwise `failed`.

--- a/services/stochastic-thinking/server.go
+++ b/services/stochastic-thinking/server.go
@@ -155,6 +155,7 @@ Supports various algorithms including:
 			"summary":   summary,
 			"hasResult": args.Result != "",
 			"nextSteps": nextSteps,
+			"hint":      "Run again with `result` populated to verify outcomes.",
 		}
 		b, _ := json.MarshalIndent(res, "", "  ")
 		out := mcp.NewToolResultText(string(b))


### PR DESCRIPTION
## Summary
- Append deterministic hint to `stochasticalgorithm` responses advising rerunning with `result`.
- Include next-thought hint in `sequentialthinking` outputs so callers know the expected thought number.
- Document new hint fields in both services' READMEs.

## Testing
- `go test ./services/stochastic-thinking` *(no tests found)*
- `go test ./services/clear-thought` *(no tests found)*
- `go build ./services/stochastic-thinking`
- `go build ./services/clear-thought`


------
https://chatgpt.com/codex/tasks/task_e_68a66ae6cd4083268d6cd59ec17630a2