### PR TITLE
Add example tools for stochastic and clear thought services

### DIFF
--- a/services/clear-thought/server.go
+++ b/services/clear-thought/server.go
@@ -191,6 +191,7 @@ func setupServer() *server.MCPServer {
 	registerTrimSession(s, session)
 	registerSessionContext(s, session)
 	registerSearchContext(s, session)
+	registerClearThoughtExamples(s)
 
 	return s
 }
@@ -740,6 +741,49 @@ func registerSearchContext(srv *server.MCPServer, state *SessionState) {
 			"nextOffset": nextOffset,
 		}
 		b, _ := json.MarshalIndent(res, "", "  ")
+		return mcp.NewToolResultText(string(b)), nil
+	})
+}
+
+func registerClearThoughtExamples(srv *server.MCPServer) {
+	tool := mcp.NewTool(
+		"clearthoughtexamples",
+		mcp.WithDescription("Sample requests for sequentialthinking, mentalmodel, and debuggingapproach"),
+	)
+
+	srv.AddTool(tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		examples := []map[string]any{
+			{
+				"tool": "sequentialthinking",
+				"args": map[string]any{
+					"thought":           "outline solution",
+					"thoughtNumber":     1,
+					"totalThoughts":     2,
+					"nextThoughtNeeded": true,
+				},
+			},
+			{
+				"tool": "mentalmodel",
+				"args": map[string]any{
+					"modelName":  "first_principles",
+					"problem":    "reduce load time",
+					"steps":      []string{"break into parts", "optimize each"},
+					"reasoning":  "start from basics",
+					"conclusion": "cache assets",
+				},
+			},
+			{
+				"tool": "debuggingapproach",
+				"args": map[string]any{
+					"approachName": "binary_search",
+					"issue":        "crash on launch",
+					"steps":        []string{"split code", "test halves"},
+					"findings":     "bad init sequence",
+					"resolution":   "fix order",
+				},
+			},
+		}
+		b, _ := json.MarshalIndent(examples, "", "  ")
 		return mcp.NewToolResultText(string(b)), nil
 	})
 }

--- a/services/stochastic-thinking/server.go
+++ b/services/stochastic-thinking/server.go
@@ -161,6 +161,55 @@ Supports various algorithms including:
 		return out, nil
 	})
 
+	examplesTool := mcp.NewTool(
+		"stochasticexamples",
+		mcp.WithDescription("Sample requests for each stochastic algorithm"),
+	)
+	s.AddTool(examplesTool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		examples := []map[string]any{
+			{
+				"algorithm": "mdp",
+				"problem":   "navigate grid",
+				"mdp": map[string]any{
+					"gamma":  0.9,
+					"states": 4,
+				},
+			},
+			{
+				"algorithm": "mcts",
+				"problem":   "choose move",
+				"mcts": map[string]any{
+					"simulations":         1000,
+					"explorationConstant": 1.4,
+				},
+			},
+			{
+				"algorithm": "bandit",
+				"problem":   "select ad",
+				"bandit": map[string]any{
+					"strategy": "epsilon_greedy",
+					"epsilon":  0.1,
+				},
+			},
+			{
+				"algorithm": "bayesian",
+				"problem":   "tune parameter",
+				"bayesian": map[string]any{
+					"acquisitionFunction": "ucb",
+				},
+			},
+			{
+				"algorithm": "hmm",
+				"problem":   "infer weather",
+				"hmm": map[string]any{
+					"algorithm": "viterbi",
+				},
+			},
+		}
+		b, _ := json.MarshalIndent(examples, "", "  ")
+		return mcp.NewToolResultText(string(b)), nil
+	})
+
 	return s
 }
 


### PR DESCRIPTION
## Summary
- add `stochasticexamples` tool with ready-to-copy requests for each stochastic algorithm
- provide `clearthoughtexamples` tool demonstrating minimal `sequentialthinking`, `mentalmodel`, and `debuggingapproach` calls

## Testing
- `go test ./services/stochastic-thinking/... ./services/clear-thought/...`


------
https://chatgpt.com/codex/tasks/task_e_68a66af8b2688326a3a53985218d064c